### PR TITLE
Ensure go.mod is tidy before running tests

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -28,6 +28,8 @@ jobs:
       with:
         go-version: 'stable'
 
+    - name: Ensure go.mod is tidy
+      run: go mod tidy
     - name: Run tests
       run: |
         go test -v ./... -count 1 || echo "No test files found"


### PR DESCRIPTION
Adds a step to run `go mod tidy` before tests in the GitHub workflow to ensure dependencies are properly configured.