### PR TITLE
Update Go version to 1.25.2

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 'stable'
+        go-version: '1.25.2'
 
     - name: Ensure go.mod is tidy
       run: go mod tidy

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.21'
+        go-version: '1.25.2'
 
     - name: Install build dependencies
       run: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dmabry/flowgre
 
-go 1.24.4
+go 1.25.2
 
 require (
 	github.com/dgraph-io/badger/v3 v3.2103.5


### PR DESCRIPTION
## Summary
- Updated go.mod to specify Go 1.25.2.
- Updated workflow files (.github/workflows/*) to use Go 1.25.2.
- Ensured all tests and builds run with the new version.