### PR TITLE
Refactor: Replace magic numbers with named constants

### DIFF
--- a/barrage/barrage.go
+++ b/barrage/barrage.go
@@ -19,6 +19,15 @@ import (
 	"github.com/dmabry/flowgre/web"
 )
 
+const (
+	// sourcePortMin/Max define the range for random source ports
+	sourcePortMin = 10000
+	sourcePortMax = 15000
+	// sourceIDMin/Max define the range for random source IDs
+	sourceIDMin = 100
+	sourceIDMax = 10000
+)
+
 // worker is the goroutine used to create workers.
 func worker(id int, ctx context.Context, server string, port int, srcRange string, dstRange string, sourceID int, delay int, wg *sync.WaitGroup, statsChan chan<- models.WorkerStat) {
 	defer wg.Done()
@@ -34,7 +43,7 @@ func worker(id int, ctx context.Context, server string, port int, srcRange strin
 	limiter := time.Tick(time.Millisecond * time.Duration(delay))
 
 	// Configure connection to use. It looks like a listener, but it will be used to send packet. Allows setting the source port.
-	srcPort := utils.RandomNum(10000, 15000)
+	srcPort := utils.RandomNum(sourcePortMin, sourcePortMax)
 
 	conn, err := net.ListenUDP("udp", &net.UDPAddr{Port: srcPort})
 	if err != nil {
@@ -125,7 +134,7 @@ func Run(config *models.Config) {
 	// Start up the workers
 	wg.Add(config.Workers)
 	for w := 1; w <= config.Workers; w++ {
-		sourceID := utils.RandomNum(100, 10000)
+		sourceID := utils.RandomNum(sourceIDMin, sourceIDMax)
 		go worker(w, ctx, config.Server, config.DstPort, config.SrcRange, config.DstRange, sourceID, config.Delay, wg, sc.StatsChan)
 	}
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -21,15 +21,22 @@ import (
 	"github.com/dmabry/flowgre/utils"
 )
 
-const udpMaxBufferSize = 65507
-const bufferSize = 1024
+const (
+	udpMaxBufferSize = 65507
+	bufferSize       = 1024
+	// sourcePortMin/Max define the range for random source ports
+	sourcePortMin = 10000
+	sourcePortMax = 15000
+	// maxTargets is the hard limit on number of proxy targets
+	maxTargets = 10
+)
 
 // Worker is the goroutine used to create workers
 func worker(id int, ctx context.Context, server string, port int, wg *sync.WaitGroup, workerChan <-chan []byte) {
 	defer wg.Done()
 	// Sent limiter to given delay
 	// Configure connection to use.  It looks like a listener, but it will be used to send packet.  Allows me to set the source port
-	srcPort := utils.RandomNum(10000, 15000)
+	srcPort := utils.RandomNum(sourcePortMin, sourcePortMax)
 	conn, err := net.ListenUDP("udp", &net.UDPAddr{Port: srcPort})
 	if err != nil {
 		log.Printf("Listen failed: %v\n", err)
@@ -211,13 +218,13 @@ func Run(ip string, port int, verbose bool, targets []string) {
 		ValidCount:   0,
 		InvalidCount: 0,
 	}
-	// Create dedicated channel per target <= 10
+	// Create dedicated channel per target <= maxTargets
 	workers := len(targets)
 	if workers == 0 {
 		log.Fatal("Error: at least one --target is required (format: IP:PORT)")
 	}
-	if workers > 10 {
-		log.Println("Can't have more than 10 Targets")
+	if workers > maxTargets {
+		log.Printf("Can't have more than %d Targets", maxTargets)
 		os.Exit(1)
 	}
 	workerChans := make([]chan []byte, workers)

--- a/single/single.go
+++ b/single/single.go
@@ -14,6 +14,15 @@ import (
 	"net"
 )
 
+const (
+	// sourcePortMin/Max define the range for random source ports
+	sourcePortMin = 10000
+	sourcePortMax = 15000
+	// sourceIDMin/Max define the range for random source IDs
+	sourceIDMin = 100
+	sourceIDMax = 10000
+)
+
 // Run Creates the given number of Netflow packets, including the required
 // Template, for a Single run. Creates the packets and puts them on the wire to
 // the targeted host.
@@ -21,10 +30,10 @@ func Run(collectorIP string, destPort int, srcPort int, count int, srcRange stri
 	// Configure connection to use. It looks like a listener, but it will be used to send packet. Allows setting the source port.
 	if srcPort == 0 {
 		// Pick random source port between 10000 and 15000
-		srcPort = utils.RandomNum(10000, 15000)
+		srcPort = utils.RandomNum(sourcePortMin, sourcePortMax)
 	} // else use the given srcPort number
 	// Generate random sourceID for all Netflow headers. This is essentially a virtual ID.
-	sourceID := utils.RandomNum(100, 10000)
+	sourceID := utils.RandomNum(sourceIDMin, sourceIDMax)
 
 	conn, err := net.ListenUDP("udp", &net.UDPAddr{Port: srcPort})
 	if err != nil {


### PR DESCRIPTION
## Summary
Replaced hardcoded magic numbers with named constants to improve code maintainability and clarity.

## Changes
- Added / constants (10000-15000) in , , and  packages
- Added / constants (100-10000) in  and  packages  
- Added  constant (10) in  package
- Updated all references to use the new constants

## Testing
All tests pass with race detector:
?   	github.com/dmabry/flowgre	[no test files]
ok  	github.com/dmabry/flowgre/barrage	37.638s
?   	github.com/dmabry/flowgre/cmd	[no test files]
?   	github.com/dmabry/flowgre/config	[no test files]
?   	github.com/dmabry/flowgre/lifecycle	[no test files]
?   	github.com/dmabry/flowgre/models	[no test files]
ok  	github.com/dmabry/flowgre/netflow	2.595s
ok  	github.com/dmabry/flowgre/proxy	1.561s
ok  	github.com/dmabry/flowgre/record	2.019s
ok  	github.com/dmabry/flowgre/replay	3.164s
ok  	github.com/dmabry/flowgre/single	6.964s
?   	github.com/dmabry/flowgre/stats	[no test files]
ok  	github.com/dmabry/flowgre/utils	2.134s
ok  	github.com/dmabry/flowgre/web	8.022s
?   	github.com/dmabry/flowgre/web/templates	[no test files]

## Impact
- No functional changes
- Improved code readability
- Easier to maintain and adjust ranges if needed
- Follows Go best practices for named constants