### PR TITLE
Remove Drone CI Badge and Replace with GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Slinging packets since 2022!
 
 For sending fabricated Netflow v9 traffic to a collector for testing
 
-[![Build Status](https://drone.dmabry.net/api/badges/dmabry/flowgre/status.svg?ref=refs/heads/main)](https://drone.dmabry.net/dmabry/flowgre)
+[![Go Tests](https://github.com/dmabry/flowgre/actions/workflows/go-test.yml/badge.svg)](https://github.com/dmabry/flowgre/actions/workflows/go-test.yml)
+[![Security Scan](https://github.com/dmabry/flowgre/actions/workflows/security.yml/badge.svg)](https://github.com/dmabry/flowgre/actions/workflows/security.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/dmabry/flowgre)](https://goreportcard.com/report/github.com/dmabry/flowgre)
 [![Go Reference](https://pkg.go.dev/badge/github.com/dmabry/flowgre.svg)](https://pkg.go.dev/github.com/dmabry/flowgre)
 


### PR DESCRIPTION
## Description
Removed deprecated Drone CI badge from README.md and replaced with active GitHub Actions workflow badges.

## Changes
- Removed: drone.dmabry.net build status badge (deprecated)
- Added: Go Tests workflow badge from GitHub Actions  
- Added: Security Scan workflow badge from GitHub Actions

## Motivation
Drone CI has been deprecated in favor of GitHub Actions. The current CI/CD infrastructure uses only GitHub Actions workflows (go-test.yml, security.yml, release.yml). This update aligns the README with the actual CI setup.

## Related
Aligns with deprecation of Drone CI infrastructure.