### PR TITLE
Add: IPv6-aware IP utilities

### DIFF
--- a/utils/ip.go
+++ b/utils/ip.go
@@ -4,6 +4,7 @@
 package utils
 
 import (
+	"crypto/rand"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -99,4 +100,104 @@ func ParseIPv4ToNum(s string) (uint32, error) {
 		return binary.BigEndian.Uint32(ip), nil
 	}
 	return 0, fmt.Errorf("unrecognized IP format: %s", s)
+}
+
+// IsIPv6CIDR detects whether a CIDR string represents an IPv6 network.
+func IsIPv6CIDR(cidr string) bool {
+	_, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return false
+	}
+	return ipNet.IP.To4() == nil
+}
+
+// RandomIPv6 generates a random IPv6 address within the given CIDR range.
+func RandomIPv6(cidr string) (net.IP, error) {
+	_, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return nil, fmt.Errorf("parsing CIDR %s: %w", cidr, err)
+	}
+	if ipNet.IP.To4() != nil {
+		return nil, fmt.Errorf("CIDR %s is IPv4, use RandomIP instead", cidr)
+	}
+
+	ip := make(net.IP, 16)
+	copy(ip, ipNet.IP)
+
+	ones, bits := ipNet.Mask.Size()
+	hostBits := bits - ones
+
+	if hostBits == 0 {
+		// /128 — single address
+		return ip, nil
+	}
+
+	// Generate random bytes for host portion
+	hostBytes := make([]byte, 16)
+	_, err = rand.Read(hostBytes)
+	if err != nil {
+		return nil, fmt.Errorf("generating random bytes: %w", err)
+	}
+
+	// Clear network bits, keep only host bits
+	for i := 0; i < 16; i++ {
+		byteBit := i * 8
+		if byteBit+8 <= ones {
+			// Entire byte is network bits — keep as-is
+			continue
+		} else if byteBit >= ones {
+			// Entire byte is host bits
+			ip[i] = hostBytes[i]
+		} else {
+			// Partial byte — boundary between network and host
+			hostBitInByte := 8 - (ones - byteBit)
+			mask := byte(0)
+			for b := 0; b < hostBitInByte; b++ {
+				mask |= byte(1) << b
+			}
+			ip[i] = ipNet.IP[i] | (hostBytes[i] & mask)
+		}
+	}
+
+	if ipNet.Contains(ip) {
+		return ip, nil
+	}
+	return nil, errors.New("random IPv6 out of range")
+}
+
+// GetLastIPv6 returns the last (broadcast-equivalent) IPv6 address in the network.
+func GetLastIPv6(ipNet *net.IPNet) net.IP {
+	ip := make(net.IP, 16)
+	copy(ip, ipNet.IP)
+
+	ones, _ := ipNet.Mask.Size()
+
+	for i := 0; i < 16; i++ {
+		byteBit := i * 8
+		if byteBit+8 <= ones {
+			// Entire byte is network bits — keep as-is
+			continue
+		} else if byteBit >= ones {
+			// Entire byte is host bits — set to 1
+			ip[i] = 0xff
+		} else {
+			// Partial byte — boundary between network and host
+			hostBitInByte := 8 - (ones - byteBit)
+			mask := byte(0)
+			for b := 0; b < hostBitInByte; b++ {
+				mask |= byte(1) << b
+			}
+			ip[i] = ipNet.IP[i] | mask
+		}
+	}
+	return ip
+}
+
+// RandomIPCIDR is a unified dispatcher that auto-detects IPv4 vs IPv6
+// and calls the appropriate random IP generation function.
+func RandomIPCIDR(cidr string) (net.IP, error) {
+	if IsIPv6CIDR(cidr) {
+		return RandomIPv6(cidr)
+	}
+	return RandomIP(cidr)
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -173,3 +173,123 @@ func TestSendPacket(t *testing.T) {
 		t.Errorf("Failed to get proper packet!")
 	}
 }
+
+func TestIsIPv6CIDR(t *testing.T) {
+	t.Parallel()
+
+	// IPv6 CIDRs
+	if !IsIPv6CIDR("2001:db8::/32") {
+		t.Error("expected 2001:db8::/32 to be IPv6")
+	}
+	if !IsIPv6CIDR("fe80::/10") {
+		t.Error("expected fe80::/10 to be IPv6")
+	}
+	if !IsIPv6CIDR("::1/128") {
+		t.Error("expected ::1/128 to be IPv6")
+	}
+
+	// IPv4 CIDRs
+	if IsIPv6CIDR("10.0.0.0/8") {
+		t.Error("expected 10.0.0.0/8 to NOT be IPv6")
+	}
+	if IsIPv6CIDR("192.168.1.0/24") {
+		t.Error("expected 192.168.1.0/24 to NOT be IPv6")
+	}
+
+	// Invalid
+	if IsIPv6CIDR("not-a-cidr") {
+		t.Error("expected invalid CIDR to return false")
+	}
+}
+
+func TestRandomIPv6(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		cidr     string
+		expected net.IP // prefix that must match
+	}{
+		{"2001:db8::/32", net.ParseIP("2001:db8::")},
+		{"fe80::/10", net.ParseIP("fe80::")},
+		{"2001:db8:1::/48", net.ParseIP("2001:db8:1::")},
+		{"2001:db8:1:2::/64", net.ParseIP("2001:db8:1:2::")},
+		{"::1/128", net.ParseIP("::1")},
+		{"::/0", net.ParseIP("::")},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.cidr, func(t *testing.T) {
+			_, ipNet, _ := net.ParseCIDR(tc.cidr)
+			for range 1000 {
+				result, err := RandomIPv6(tc.cidr)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if !ipNet.Contains(result) {
+					t.Errorf("IP %s not in CIDR %s", result, tc.cidr)
+				}
+				if result.To4() != nil {
+					t.Errorf("expected IPv6, got IPv4: %s", result)
+				}
+			}
+		})
+	}
+}
+
+func TestRandomIPv6RejectsIPv4(t *testing.T) {
+	t.Parallel()
+
+	_, err := RandomIPv6("10.0.0.0/8")
+	if err == nil {
+		t.Error("expected error for IPv4 CIDR")
+	}
+}
+
+func TestGetLastIPv6(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		cidr     string
+		expected string
+	}{
+		{"2001:db8::/32", "2001:db8:ffff:ffff:ffff:ffff:ffff:ffff"},
+		{"fe80::/10", "febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff"},
+		{"2001:db8:1::/48", "2001:db8:1:ffff:ffff:ffff:ffff:ffff"},
+		{"2001:db8:1:2::/64", "2001:db8:1:2:ffff:ffff:ffff:ffff"},
+		{"::1/128", "::1"},
+		{"::/0", "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.cidr, func(t *testing.T) {
+			_, ipNet, _ := net.ParseCIDR(tc.cidr)
+			last := GetLastIPv6(ipNet)
+			expected := net.ParseIP(tc.expected)
+			if !last.Equal(expected) {
+				t.Errorf("expected %s, got %s", expected, last)
+			}
+		})
+	}
+}
+
+func TestRandomIPCIDR(t *testing.T) {
+	t.Parallel()
+
+	// IPv4 CIDR should return IPv4
+	ip, err := RandomIPCIDR("10.0.0.0/8")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ip.To4() == nil {
+		t.Error("expected IPv4 for IPv4 CIDR")
+	}
+
+	// IPv6 CIDR should return IPv6
+	ip, err = RandomIPCIDR("2001:db8::/32")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ip.To4() != nil {
+		t.Error("expected IPv6 for IPv6 CIDR")
+	}
+}


### PR DESCRIPTION
## Summary

Extends `utils/ip.go` with IPv6-capable IP generation and manipulation functions.

## New Functions

- **`IsIPv6CIDR(cidr string) bool`** — Detects whether a CIDR is IPv6
- **`RandomIPv6(cidr string) (net.IP, error)`** — Random IPv6 within CIDR range using `crypto/rand`
- **`GetLastIPv6(ipNet *net.IPNet) net.IP`** — Last/broadcast-equivalent IPv6 in network
- **`RandomIPCIDR(cidr string) (net.IP, error)`** — Unified dispatcher (auto-detects IPv4 vs IPv6)

## Tests

- `TestIsIPv6CIDR` — IPv6, IPv4, and invalid CIDR detection
- `TestRandomIPv6` — 1000 iterations across 6 CIDR ranges (including edge cases /128, /0, /10)
- `TestRandomIPv6RejectsIPv4` — Error on IPv4 CIDR input
- `TestGetLastIPv6` — Correct last IP for /32, /10, /48, /64, /128, /0
- `TestRandomIPCIDR` — Dispatcher routes IPv4 and IPv6 correctly

## Verification

- `go test -v ./utils/... -count 1` — all pass
- `go test -race ./utils/...` — all pass
- `go build ./...` — clean build
- No regressions in existing IPv4 tests