### PR TITLE
refactor: fix StatsMap race condition, remove test stubs, update version

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 	"github.com/dmabry/flowgre/cmd"
 )
 
-var version = "0.4.10" // semantic version — overridden by -ldflags at build time
+var version = "0.5.15" // semantic version — overridden by -ldflags at build time
 const license = "Apache License, Version 2.0"
 
 func main() {

--- a/stats/collector.go
+++ b/stats/collector.go
@@ -26,6 +26,7 @@ const (
 
 // Collector gathers stats about barrage workers and emits them via stdout and web UI.
 type Collector struct {
+	mu          sync.RWMutex
 	StatsMap    map[int]models.WorkerStat
 	StatsChan   chan models.WorkerStat
 	StatsTotals models.StatTotals
@@ -56,16 +57,18 @@ func (sc *Collector) Run(wg *sync.WaitGroup, ctx context.Context) {
 				default:
 					sizeOut = stat.BytesSent
 				}
-				log.Printf("Worker [%2d] SourceID: %4d Cycles: %d Flows Sent: %d Bytes Sent: %d %s\n",
-					stat.WorkerID, stat.SourceID, stat.Cycles, stat.FlowsSent, sizeOut, sizeLabel)
-				sc.StatsMap[stat.WorkerID] = stat
-				// Recalculate totals from map to avoid double-counting cumulative stats
-				sc.StatsTotals = models.StatTotals{}
-				for _, s := range sc.StatsMap {
-					sc.StatsTotals.Cycles += s.Cycles
-					sc.StatsTotals.FlowsSent += s.FlowsSent
-					sc.StatsTotals.BytesSent += s.BytesSent
-				}
+			log.Printf("Worker [%2d] SourceID: %4d Cycles: %d Flows Sent: %d Bytes Sent: %d %s\n",
+				stat.WorkerID, stat.SourceID, stat.Cycles, stat.FlowsSent, sizeOut, sizeLabel)
+			sc.mu.Lock()
+			sc.StatsMap[stat.WorkerID] = stat
+			// Recalculate totals from map to avoid double-counting cumulative stats
+			sc.StatsTotals = models.StatTotals{}
+			for _, s := range sc.StatsMap {
+				sc.StatsTotals.Cycles += s.Cycles
+				sc.StatsTotals.FlowsSent += s.FlowsSent
+				sc.StatsTotals.BytesSent += s.BytesSent
+			}
+			sc.mu.Unlock()
 			} else {
 				log.Println("Stats Channel Closed!")
 			}
@@ -85,7 +88,14 @@ func (sc *Collector) Run(wg *sync.WaitGroup, ctx context.Context) {
 
 // StatsHandler emits worker stats as JSON for the web API.
 func (sc *Collector) StatsHandler(w http.ResponseWriter, r *http.Request) {
-	err := json.NewEncoder(w).Encode(sc.StatsMap)
+	sc.mu.RLock()
+	statsCopy := make(map[int]models.WorkerStat, len(sc.StatsMap))
+	for k, v := range sc.StatsMap {
+		statsCopy[k] = v
+	}
+	sc.mu.RUnlock()
+
+	err := json.NewEncoder(w).Encode(statsCopy)
 	if err != nil {
 		log.Printf("Web server had an issue: %v\n", err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
@@ -94,6 +104,14 @@ func (sc *Collector) StatsHandler(w http.ResponseWriter, r *http.Request) {
 
 // DashboardHandler renders the dashboard HTML page with current stats.
 func (sc *Collector) DashboardHandler(w http.ResponseWriter, r *http.Request) {
+	sc.mu.RLock()
+	statsCopy := make(map[int]models.WorkerStat, len(sc.StatsMap))
+	for k, v := range sc.StatsMap {
+		statsCopy[k] = v
+	}
+	totalsCopy := sc.StatsTotals
+	sc.mu.RUnlock()
+
 	d := models.DashboardPage{
 		Title:   "Flowgre Dashboard",
 		Comment: "Basic metrics about flowgre",
@@ -102,8 +120,8 @@ func (sc *Collector) DashboardHandler(w http.ResponseWriter, r *http.Request) {
 			Message: "Flowgre is Flinging Packets!",
 		},
 		ConfigOut:   sc.Config,
-		StatsMapOut: sc.StatsMap,
-		StatsTotal:  sc.StatsTotals,
+		StatsMapOut: statsCopy,
+		StatsTotal:  totalsCopy,
 	}
 
 	t, err := template.New("dashboard").Parse(templates.DashboardTpl)

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -8,6 +8,7 @@ package utils
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/gob"
 	"net"
 	"strings"
 	"testing"
@@ -96,7 +97,36 @@ func TestRandomNum(t *testing.T) {
 
 func TestToBytes(t *testing.T) {
 	t.Parallel()
-	//Stub TODO: Make a test that is actually applicable.  The function isn't used currently
+
+	// Test with a simple struct
+	type TestStruct struct {
+		Name  string
+		Value int
+	}
+	original := TestStruct{Name: "flowgre", Value: 42}
+
+	data, err := ToBytes(original)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("expected non-empty byte slice")
+	}
+
+	// Verify we can decode it back
+	var buf bytes.Buffer
+	buf.Write(data)
+	dec := gob.NewDecoder(&buf)
+	var decoded TestStruct
+	if err := dec.Decode(&decoded); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+	if decoded.Name != original.Name {
+		t.Errorf("expected Name %q, got %q", original.Name, decoded.Name)
+	}
+	if decoded.Value != original.Value {
+		t.Errorf("expected Value %d, got %d", original.Value, decoded.Value)
+	}
 }
 
 func TestRandomIP(t *testing.T) {

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -21,7 +21,7 @@ type Response struct {
 	Message string `json:"message"`
 }
 
-// TestRun runs a test to verify functionality. TODO: Need to determine a sane test for this
+// TestRun verifies that the web server starts, serves the dashboard, and returns valid JSON.
 func TestRun(t *testing.T) {
 	t.Parallel()
 	wg := &sync.WaitGroup{}


### PR DESCRIPTION
## Summary

Five code quality fixes:

### 1. StatsMap Race Condition Fix (High Priority)
Added `sync.RWMutex` to `Collector` to protect `StatsMap` and `StatsTotals` from concurrent access:
- `Run()` — write lock around map updates
- `StatsHandler()` — read lock + copy before JSON encoding
- `DashboardHandler()` — read lock + copy before template rendering

### 2. Web Test Stub Removed
Updated `TestRun` comment — the test works fine, the TODO was stale.

### 3. Utils ToBytes Test Stub Replaced
Replaced the stub test with a real gob encode/decode round-trip test.

### 4. Default Version Updated
Changed fallback version from `0.4.10` to `0.5.15` to match latest tag.

### 5. Import Cleanup
Added `encoding/gob` import to utils test file for the new ToBytes test.

All tests pass with `-race` detector.