### PR TITLE
Test: add integration tests for record/replay pipeline

### DIFF
--- a/barrage/barrage.go
+++ b/barrage/barrage.go
@@ -169,47 +169,16 @@ func RunCtx(ctx context.Context, config *models.Config, gen FlowGenerator) {
 // Use RunCtx() when you need to control the lifecycle via context.
 func Run(config *models.Config, gen FlowGenerator) {
 	mgr := lifecycle.New()
-	ctx := mgr.Context()
-	wg := mgr.WaitGroup()
-
-	buffer := 20
-	// Start the StatsCollector
-	sc := &stats.Collector{
-		StartTime: time.Now(),
-	}
-	sc.StatsChan = make(chan models.WorkerStat, config.Workers+buffer)
-	sc.StatsMap = make(map[int]models.WorkerStat)
-	sc.StatsTotals = models.StatTotals{
-		FlowsSent: 0,
-		Cycles:    0,
-		BytesSent: 0,
-	}
-	sc.Config = config
-	wg.Add(1)
-	go sc.Run(wg, ctx)
-
-	// Default template retransmission interval is 30 seconds if not set
-	templateInterval := config.TemplateInterval
-	if templateInterval <= 0 {
-		templateInterval = 30
-	}
-
-	// Start up the workers
-	wg.Add(config.Workers)
-	for w := 1; w <= config.Workers; w++ {
-		sourceID := utils.RandomNum(sourceIDMin, sourceIDMax)
-		go worker(w, ctx, config.Server, config.DstPort, config.SrcRange, config.DstRange, sourceID, config.Delay, templateInterval, wg, sc.StatsChan, gen)
-	}
-
-	// Start WebServer if needed
-	if config.Web {
-		wg.Add(1)
-		go web.RunWebServer(config.WebIP, config.WebPort, wg, ctx, sc)
-	}
 
 	// Setup signal handling via lifecycle manager
 	cleanupDone := mgr.SetupSignalHandler()
-	<-cleanupDone
+
+	go func() {
+		<-cleanupDone
+		log.Printf("Received signal, shutting down...\n")
+		mgr.Cancel()
+	}()
+
+	RunCtx(mgr.Context(), config, gen)
 	mgr.Wait()
-	sc.Stop()
 }

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1,0 +1,388 @@
+//go:build integration
+
+// Integration tests for the full record→replay pipeline.
+// Exercises real UDP sockets, BadgerDB storage, and binary round-trips.
+//
+// Run with: go test -tags=integration -v ./integration
+package integration
+
+import (
+	"context"
+	"encoding/binary"
+	"math/rand"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	badger "github.com/dgraph-io/badger/v3"
+	"github.com/dmabry/flowgre/ipfix"
+	"github.com/dmabry/flowgre/netflow"
+	"github.com/dmabry/flowgre/record"
+	"github.com/dmabry/flowgre/single"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func pickPort(t *testing.T) int {
+	t.Helper()
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatalf("pickPort: %v", err)
+	}
+	port := conn.LocalAddr().(*net.UDPAddr).Port
+	conn.Close()
+	return port
+}
+
+func countDBEntries(t *testing.T, dir string) (total, v9, v10 int) {
+	t.Helper()
+	db, err := badger.Open(badger.DefaultOptions(dir).WithReadOnly(true))
+	if err != nil {
+		t.Fatalf("countDBEntries: %v", err)
+	}
+	defer db.Close()
+
+	err = db.View(func(txn *badger.Txn) error {
+		it := txn.NewIterator(badger.DefaultIteratorOptions)
+		defer it.Close()
+		for it.Rewind(); it.Valid(); it.Next() {
+			val, err := it.Item().ValueCopy(nil)
+			if err != nil || len(val) < 2 {
+				continue
+			}
+			total++
+			switch binary.BigEndian.Uint16(val[:2]) {
+			case 9:
+				v9++
+			case 10:
+				v10++
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return
+}
+
+func startRecorder(ctx context.Context, t *testing.T, ip string, port int, dbDir string) func() {
+	t.Helper()
+	ctx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	go func() {
+		record.RunCtx(ctx, ip, port, dbDir, false)
+		close(done)
+	}()
+	time.Sleep(500 * time.Millisecond)
+	return func() { cancel(); <-done }
+}
+
+func sendRawPacket(t *testing.T, port int, data []byte) {
+	t.Helper()
+	conn, err := net.DialUDP("udp", nil, &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: port})
+	if err != nil {
+		t.Fatalf("sendRawPacket: %v", err)
+	}
+	defer conn.Close()
+	if _, err := conn.Write(data); err != nil {
+		t.Fatalf("sendRawPacket write: %v", err)
+	}
+}
+
+// sendIPFIX sends IPFIX packets directly using the ipfix package.
+func sendIPFIX(t *testing.T, port int, count int) {
+	t.Helper()
+	session := netflow.NewSession()
+	conn, err := net.DialUDP("udp", nil, &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: port})
+	if err != nil {
+		t.Fatalf("sendIPFIX dial: %v", err)
+	}
+	defer conn.Close()
+
+	// Send template
+	tpl := ipfix.GenerateTemplateIPFIX(1, session)
+	tplBuf := tpl.ToBytes()
+	conn.Write(tplBuf.Bytes())
+
+	// Send data flows
+	for i := 0; i < count; i++ {
+		pkt := ipfix.GenerateDataIPFIX(1, 1, "10.0.0.0/8", "172.16.0.0/12", 0, session)
+		pktBuf := pkt.ToBytes()
+		conn.Write(pktBuf.Bytes())
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// replayFromDB reads packets from a BadgerDB and sends them to the given port.
+func replayFromDB(t *testing.T, dbDir string, port int) {
+	t.Helper()
+	db, err := badger.Open(badger.DefaultOptions(dbDir).WithReadOnly(true))
+	if err != nil {
+		t.Fatalf("replayFromDB open: %v", err)
+	}
+	defer db.Close()
+
+	conn, err := net.DialUDP("udp", nil, &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: port})
+	if err != nil {
+		t.Fatalf("replayFromDB dial: %v", err)
+	}
+	defer conn.Close()
+
+	err = db.View(func(txn *badger.Txn) error {
+		it := txn.NewIterator(badger.DefaultIteratorOptions)
+		defer it.Close()
+		for it.Rewind(); it.Valid(); it.Next() {
+			val, err := it.Item().ValueCopy(nil)
+			if err != nil {
+				continue
+			}
+			conn.Write(val)
+			time.Sleep(10 * time.Millisecond)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("replayFromDB iterate: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+func TestRoundTrip_NetFlow(t *testing.T) {
+	t.Parallel()
+	tmpDir := mustTempDir(t)
+	defer os.RemoveAll(tmpDir)
+
+	recPort := pickPort(t)
+	replayPort := pickPort(t)
+	recDB := filepath.Join(tmpDir, "rec")
+	replayDB := filepath.Join(tmpDir, "replay")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stopRec := startRecorder(ctx, t, "127.0.0.1", recPort, recDB)
+	stopReplay := startRecorder(ctx, t, "127.0.0.1", replayPort, replayDB)
+
+	// Generate NetFlow v9 via single.RunCtx
+	sCtx, sCancel := context.WithCancel(context.Background())
+	sDone := make(chan struct{})
+	go func() {
+		single.RunCtx(sCtx, "127.0.0.1", recPort, 0, 10, "10.0.0.0/8", "172.16.0.0/12", false)
+		close(sDone)
+	}()
+	// Wait for sender to finish (it sends 10 flows then exits)
+	select {
+	case <-sDone:
+	case <-time.After(10 * time.Second):
+		sCancel()
+	}
+	sCancel()
+
+	time.Sleep(300 * time.Millisecond)
+	stopRec()
+	stopReplay()
+	cancel()
+
+	total, v9, v10 := countDBEntries(t, recDB)
+	if v9 != 11 {
+		t.Errorf("NetFlow record: expected 11 v9 packets, got %d (total=%d, v10=%d)", v9, total, v10)
+	}
+	if v10 != 0 {
+		t.Errorf("NetFlow record: expected 0 v10 packets, got %d", v10)
+	}
+
+	// Replay through second recorder
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+	stopReplay2 := startRecorder(ctx2, t, "127.0.0.1", replayPort, replayDB)
+
+	replayFromDB(t, recDB, replayPort)
+	time.Sleep(300 * time.Millisecond)
+	stopReplay2()
+	cancel2()
+
+	rtTotal, rtV9, rtV10 := countDBEntries(t, replayDB)
+	if rtV9 != 11 {
+		t.Errorf("NetFlow replay: expected 11 v9 packets, got %d (total=%d, v10=%d)", rtV9, rtTotal, rtV10)
+	}
+}
+
+func TestRoundTrip_IPFIX(t *testing.T) {
+	t.Parallel()
+	tmpDir := mustTempDir(t)
+	defer os.RemoveAll(tmpDir)
+
+	recPort := pickPort(t)
+	replayPort := pickPort(t)
+	recDB := filepath.Join(tmpDir, "rec")
+	replayDB := filepath.Join(tmpDir, "replay")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stopRec := startRecorder(ctx, t, "127.0.0.1", recPort, recDB)
+	stopReplay := startRecorder(ctx, t, "127.0.0.1", replayPort, replayDB)
+
+	// Generate IPFIX via direct package API
+	sendIPFIX(t, recPort, 10)
+	time.Sleep(300 * time.Millisecond)
+
+	stopRec()
+	stopReplay()
+	cancel()
+
+	total, v9, v10 := countDBEntries(t, recDB)
+	if v10 != 11 {
+		t.Errorf("IPFIX record: expected 11 v10 packets, got %d (total=%d, v9=%d)", v10, total, v9)
+	}
+	if v9 != 0 {
+		t.Errorf("IPFIX record: expected 0 v9 packets, got %d", v9)
+	}
+
+	// Replay
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+	stopReplay2 := startRecorder(ctx2, t, "127.0.0.1", replayPort, replayDB)
+
+	replayFromDB(t, recDB, replayPort)
+	time.Sleep(300 * time.Millisecond)
+	stopReplay2()
+	cancel2()
+
+	rtTotal, rtV9, rtV10 := countDBEntries(t, replayDB)
+	if rtV10 != 11 {
+		t.Errorf("IPFIX replay: expected 11 v10 packets, got %d (total=%d, v9=%d)", rtV10, rtTotal, rtV9)
+	}
+}
+
+func TestNegative_GarbageRejected(t *testing.T) {
+	t.Parallel()
+	tmpDir := mustTempDir(t)
+	defer os.RemoveAll(tmpDir)
+
+	port := pickPort(t)
+	dbDir := filepath.Join(tmpDir, "neg")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stop := startRecorder(ctx, t, "127.0.0.1", port, dbDir)
+
+	tests := []struct {
+		label string
+		data  []byte
+	}{
+		{"random-256", makeRandom(256)},
+		{"ver-99", makeFakeHeader(99, 20)},
+		{"tiny-2", []byte{0xFF, 0xFE}},
+		{"empty-4", make([]byte, 4)},
+		{"dns-like", makeFakeHeader(0xABCD, 60)},
+		{"fake-nfv9", makeFakeHeader(9, 100)},
+		{"fake-ipfix", makeFakeHeader(10, 128)},
+		{"seq-noise", makeSequential(512)},
+		{"icmp-like", makeFakeHeader(0x0800, 64)},
+		{"all-zeros", make([]byte, 100)},
+	}
+
+	for _, tt := range tests {
+		sendRawPacket(t, port, tt.data)
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	time.Sleep(500 * time.Millisecond)
+	cancel()
+	stop()
+
+	total, v9, v10 := countDBEntries(t, dbDir)
+	const wantTotal = 2
+	const wantV9 = 1
+	const wantV10 = 1
+
+	if total != wantTotal {
+		t.Errorf("stored %d packets, expected %d", total, wantTotal)
+		for i, tt := range tests {
+			t.Logf("  [%d] %-15s (%d bytes)", i, tt.label, len(tt.data))
+		}
+	}
+	if v9 != wantV9 {
+		t.Errorf("v9 count: got %d, want %d", v9, wantV9)
+	}
+	if v10 != wantV10 {
+		t.Errorf("v10 count: got %d, want %d", v10, wantV10)
+	}
+}
+
+func TestValidation_Unit(t *testing.T) {
+	t.Parallel()
+
+	if ok, err := netflow.IsValidNetFlow([]byte{9}, 9); ok || err == nil {
+		t.Error("NetFlow: too-short payload should error")
+	}
+	if ok, err := ipfix.IsValidIPFIX([]byte{10}); ok || err == nil {
+		t.Error("IPFIX: too-short payload should error")
+	}
+
+	wrongNF := makeFakeHeader(10, 20)
+	ok, err := netflow.IsValidNetFlow(wrongNF, 9)
+	if ok || err == nil {
+		t.Error("NetFlow: version mismatch should fail")
+	}
+
+	wrongIPFIX := makeFakeHeader(9, 20)
+	ok, err = ipfix.IsValidIPFIX(wrongIPFIX)
+	if ok || err == nil {
+		t.Error("IPFIX: version mismatch should fail")
+	}
+
+	validNF := makeFakeHeader(9, 100)
+	ok, err = netflow.IsValidNetFlow(validNF, 9)
+	if !ok || err != nil {
+		t.Errorf("NetFlow: valid v9 should pass: ok=%v, err=%v", ok, err)
+	}
+
+	validIPFIX := makeFakeHeader(10, 128)
+	ok, err = ipfix.IsValidIPFIX(validIPFIX)
+	if !ok || err != nil {
+		t.Errorf("IPFIX: valid v10 should pass: ok=%v, err=%v", ok, err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func mustTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "flowgre-int-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func makeFakeHeader(version uint16, size int) []byte {
+	buf := make([]byte, size)
+	binary.BigEndian.PutUint16(buf[:2], version)
+	binary.BigEndian.PutUint32(buf[4:8], 1)
+	return buf
+}
+
+func makeRandom(size int) []byte {
+	buf := make([]byte, size)
+	rand.Read(buf)
+	return buf
+}
+
+func makeSequential(size int) []byte {
+	buf := make([]byte, size)
+	for i := range buf {
+		buf[i] = byte(i)
+	}
+	return buf
+}

--- a/record/record.go
+++ b/record/record.go
@@ -153,11 +153,11 @@ func parseFlow(ctx context.Context, wg *sync.WaitGroup, parseChan <-chan []byte,
 	}
 }
 
-// Run Record. Kicks off the recording process.
-func Run(ip string, port int, dbdir string, verbose bool) {
-	mgr := lifecycle.New()
-	ctx := mgr.Context()
-	wg := mgr.WaitGroup()
+// RunCtx starts the recording process with an external context.
+// Cancelling ctx stops all workers cleanly. Use Run() for CLI usage
+// where OS signal handling is desired.
+func RunCtx(ctx context.Context, ip string, port int, dbdir string, verbose bool) {
+	wg := &sync.WaitGroup{}
 	dataChan := make(chan []byte, 1024)
 	parseChan := make(chan []byte, 1024)
 
@@ -172,6 +172,17 @@ func Run(ip string, port int, dbdir string, verbose bool) {
 	// Start dbIngest
 	wg.Add(1)
 	go dbIngest(ctx, wg, dbdir, dataChan, verbose)
+
+	// Wait for all goroutines to finish
+	wg.Wait()
+}
+
+// Run Record. Kicks off the recording process.
+// It sets up OS signal handling (SIGINT/SIGTERM) for clean shutdown.
+// Use RunCtx() when you need to control the lifecycle via context.
+func Run(ip string, port int, dbdir string, verbose bool) {
+	mgr := lifecycle.New()
+	RunCtx(mgr.Context(), ip, port, dbdir, verbose)
 
 	// Setup signal handling via lifecycle manager
 	cleanupDone := mgr.SetupSignalHandler()

--- a/replay/replay.go
+++ b/replay/replay.go
@@ -130,11 +130,12 @@ func dbReader(ctx context.Context, wg *sync.WaitGroup, dbdir string, dataChan ch
 	return
 }
 
-// Run Replay. Kicks off the replay of netflow packets from a db.
-func Run(server string, port int, delay int, dbdir string, loop bool, workers int, updateTS bool, verbose bool) {
-	mgr := lifecycle.New()
-	ctx := mgr.Context()
-	wg := mgr.WaitGroup()
+// RunCtx replays netflow packets from a db with an external context.
+// Cancelling ctx stops all workers cleanly. In non-loop mode, the function
+// returns when all packets have been sent. Use Run() for CLI usage where
+// OS signal handling is desired.
+func RunCtx(ctx context.Context, server string, port int, delay int, dbdir string, loop bool, workers int, updateTS bool, verbose bool) {
+	wg := &sync.WaitGroup{}
 	dataChan := make(chan []byte, 1024)
 
 	// Start dbReader
@@ -147,33 +148,30 @@ func Run(server string, port int, delay int, dbdir string, loop bool, workers in
 		go worker(w, ctx, server, port, delay, wg, loop, dataChan)
 	}
 
+	// Wait for all goroutines to finish
+	wg.Wait()
+
+	// Log completion if context was not cancelled (natural completion)
+	if ctx.Err() == nil {
+		log.Printf("\nReplay complete, shutting down...\n")
+	}
+}
+
+// Run Replay. Kicks off the replay of netflow packets from a db.
+// It sets up OS signal handling (SIGINT/SIGTERM) for clean shutdown.
+// Use RunCtx() when you need to control the lifecycle via context.
+func Run(server string, port int, delay int, dbdir string, loop bool, workers int, updateTS bool, verbose bool) {
+	mgr := lifecycle.New()
+
 	// Setup signal handling via lifecycle manager.
-	// For non-loop mode, also detect when replay is complete (dataChan empty).
-	cleanupDone := make(chan bool, 1)
-	sigCleanup := mgr.SetupSignalHandler()
+	cleanupDone := mgr.SetupSignalHandler()
 
 	go func() {
-		for {
-			select {
-			case <-sigCleanup:
-				log.Printf("\rReceived signal, shutting down...\n\n")
-				mgr.Cancel()
-				cleanupDone <- true
-			case <-ctx.Done():
-				if !loop && len(dataChan) == 0 {
-					log.Printf("Replay complete, shutting down...\n\n")
-				}
-				cleanupDone <- true
-			case <-time.After(time.Second * 1):
-				if !loop && len(dataChan) == 0 {
-					log.Printf("Replay complete, shutting down...\n\n")
-					mgr.Cancel()
-					cleanupDone <- true
-				}
-			}
-		}
+		<-cleanupDone
+		log.Printf("\rReceived signal, shutting down...\n\n")
+		mgr.Cancel()
 	}()
 
-	<-cleanupDone
+	RunCtx(mgr.Context(), server, port, delay, dbdir, loop, workers, updateTS, verbose)
 	mgr.Wait()
 }

--- a/single/single.go
+++ b/single/single.go
@@ -6,8 +6,10 @@
 package single
 
 import (
+	"context"
 	"encoding/hex"
 	"fmt"
+	"github.com/dmabry/flowgre/lifecycle"
 	"github.com/dmabry/flowgre/netflow"
 	"github.com/dmabry/flowgre/utils"
 	"log"
@@ -23,10 +25,11 @@ const (
 	sourceIDMax = 10000
 )
 
-// Run Creates the given number of Netflow packets, including the required
-// Template, for a Single run. Creates the packets and puts them on the wire to
-// the targeted host.
-func Run(collectorIP string, destPort int, srcPort int, count int, srcRange string, dstRange string, hexDump bool) {
+// RunCtx creates the given number of Netflow packets, including the required
+// Template, for a Single run with an external context. Cancelling ctx stops
+// packet generation cleanly. Use Run() for CLI usage where OS signal handling
+// is desired.
+func RunCtx(ctx context.Context, collectorIP string, destPort int, srcPort int, count int, srcRange string, dstRange string, hexDump bool) {
 	// Configure connection to use. It looks like a listener, but it will be used to send packet. Allows setting the source port.
 	if srcPort == 0 {
 		// Pick random source port between 10000 and 15000
@@ -39,6 +42,7 @@ func Run(collectorIP string, destPort int, srcPort int, count int, srcRange stri
 	if err != nil {
 		log.Fatal("Listen:", err)
 	}
+	defer conn.Close()
 	// Convert given IP String to net.IP type
 	destIP := net.ParseIP(collectorIP)
 	if destIP == nil {
@@ -63,6 +67,12 @@ func Run(collectorIP string, destPort int, srcPort int, count int, srcRange stri
 	// Generate and send Data Flow(s)
 	fmt.Printf("\nSending Data Flows\n\n")
 	for i := 1; i <= count; i++ {
+		select {
+		case <-ctx.Done():
+			log.Printf("Single run cancelled after %d/%d packets\n", i-1, count)
+			return
+		default:
+		}
 		flow := netflow.GenerateDataNetflow(10, sourceID, srcRange, dstRange, 0, session)
 		buf := flow.ToBytes()
 		fmt.Println(netflow.GetNetFlowSizes(flow))
@@ -74,4 +84,23 @@ func Run(collectorIP string, destPort int, srcPort int, count int, srcRange stri
 			log.Fatalf("Flowgre had an issue sending packet %v\n", err)
 		}
 	}
+}
+
+// Run Creates the given number of Netflow packets, including the required
+// Template, for a Single run. Creates the packets and puts them on the wire to
+// the targeted host. Sets up OS signal handling (SIGINT/SIGTERM) for clean
+// shutdown. Use RunCtx() when you need to control the lifecycle via context.
+func Run(collectorIP string, destPort int, srcPort int, count int, srcRange string, dstRange string, hexDump bool) {
+	mgr := lifecycle.New()
+
+	// Setup signal handling via lifecycle manager
+	cleanupDone := mgr.SetupSignalHandler()
+	go func() {
+		<-cleanupDone
+		log.Printf("Received signal, shutting down...\n")
+		mgr.Cancel()
+	}()
+
+	RunCtx(mgr.Context(), collectorIP, destPort, srcPort, count, srcRange, dstRange, hexDump)
+	mgr.Wait()
 }


### PR DESCRIPTION
## Changes

**Integration Tests** (`integration/integration_test.go`)
- `TestRoundTrip_NetFlow` — generates NetFlow v9 via `single.RunCtx`, records, replays through second recorder, verifies 11 packets preserved
- `TestRoundTrip_IPFIX` — same for IPFIX v10 via direct package API
- `TestNegative_GarbageRejected` — sends 10 junk payloads (random bytes, wrong versions, truncated packets, DNS/ICMP-like), verifies only 2 with valid version headers stored
- `TestValidation_Unit` — unit tests for `IsValidNetFlow`/ `IsValidIPFIX` edge cases

**RunCtx Variants** (4 packages)
- `record.RunCtx(ctx)` — context-aware recording with graceful shutdown
- `replay.RunCtx(ctx)` — context-aware replay with graceful shutdown
- `single.RunCtx(ctx)` — context-aware single-send with graceful shutdown
- `barrage.Run()` refactored to delegate to existing `RunCtx()`

Pattern: `Run()` wraps `RunCtx(lifecycle.New().Context())` with signal handling.

**Run Locally**
```bash
go test -tags=integration -v -race -timeout=120s ./integration/
```

**CI Compatibility**
Gated behind `-tags=integration` (opt-in). Safe to add to CI via:
```yaml
- name: Integration Tests
  run: go test -tags=integration -v -race -timeout=120s ./integration/
```