### PR TITLE
fix: propagate errors from DataFlowSet.Generate()

### DIFF
--- a/barrage/generator.go
+++ b/barrage/generator.go
@@ -4,6 +4,8 @@
 package barrage
 
 import (
+	"fmt"
+
 	"github.com/dmabry/flowgre/ipfix"
 	"github.com/dmabry/flowgre/netflow"
 )
@@ -41,7 +43,10 @@ func (g netflowGenerator) GenerateOptionsData(sourceID int, session *netflow.Ses
 }
 
 func (g netflowGenerator) GenerateData(flowCount int, sourceID int, srcRange, dstRange string, session *netflow.Session) []byte {
-	flow := netflow.GenerateDataNetflow(flowCount, sourceID, srcRange, dstRange, 0, session, g.profile)
+	flow, err := netflow.GenerateDataNetflow(flowCount, sourceID, srcRange, dstRange, 0, session, g.profile)
+	if err != nil {
+		panic(fmt.Sprintf("GenerateDataNetflow failed: %v", err))
+	}
 	buf := flow.ToBytes()
 	return buf.Bytes()
 }
@@ -64,7 +69,10 @@ func (g ipfixGenerator) GenerateOptionsData(sourceID int, session *netflow.Sessi
 }
 
 func (g ipfixGenerator) GenerateData(flowCount int, sourceID int, srcRange, dstRange string, session *netflow.Session) []byte {
-	flow := ipfix.GenerateDataIPFIX(flowCount, sourceID, srcRange, dstRange, 0, session)
+	flow, err := ipfix.GenerateDataIPFIX(flowCount, sourceID, srcRange, dstRange, 0, session)
+	if err != nil {
+		panic(fmt.Sprintf("GenerateDataIPFIX failed: %v", err))
+	}
 	buf := flow.ToBytes()
 	return buf.Bytes()
 }

--- a/bench/bench_test.go
+++ b/bench/bench_test.go
@@ -49,7 +49,10 @@ func BenchmarkNetflow_FullPacket_Generic(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for b.Loop() {
-		nf := netflow.GenerateNetflow(flowCount, sourceID, srcRange, dstRange, session)
+		nf, err := netflow.GenerateNetflow(flowCount, sourceID, srcRange, dstRange, session)
+		if err != nil {
+			b.Fatal(err)
+		}
 		_ = nf.ToBytes()
 	}
 }
@@ -66,7 +69,10 @@ func BenchmarkNetflow_DataOnly_Generic(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for b.Loop() {
-		nf := netflow.GenerateDataNetflow(flowCount, sourceID, srcRange, dstRange, 0, session)
+		nf, err := netflow.GenerateDataNetflow(flowCount, sourceID, srcRange, dstRange, 0, session)
+		if err != nil {
+			b.Fatal(err)
+		}
 		_ = nf.ToBytes()
 	}
 }
@@ -82,7 +88,10 @@ func BenchmarkNetflow_DataOnly_Minimal(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for b.Loop() {
-		nf := netflow.GenerateDataNetflow(flowCount, sourceID, srcRange, dstRange, 0, session, &netflow.MinimalProfile{})
+		nf, err := netflow.GenerateDataNetflow(flowCount, sourceID, srcRange, dstRange, 0, session, &netflow.MinimalProfile{})
+		if err != nil {
+			b.Fatal(err)
+		}
 		_ = nf.ToBytes()
 	}
 }
@@ -98,7 +107,10 @@ func BenchmarkNetflow_DataOnly_Extended(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for b.Loop() {
-		nf := netflow.GenerateDataNetflow(flowCount, sourceID, srcRange, dstRange, 0, session, &netflow.ExtendedProfile{})
+		nf, err := netflow.GenerateDataNetflow(flowCount, sourceID, srcRange, dstRange, 0, session, &netflow.ExtendedProfile{})
+		if err != nil {
+			b.Fatal(err)
+		}
 		_ = nf.ToBytes()
 	}
 }
@@ -116,7 +128,10 @@ func BenchmarkIPFIX_DataOnly_Generic(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for b.Loop() {
-		pkt := ipfix.GenerateDataIPFIX(flowCount, sourceID, srcRange, dstRange, 0, session)
+		pkt, err := ipfix.GenerateDataIPFIX(flowCount, sourceID, srcRange, dstRange, 0, session)
+		if err != nil {
+			b.Fatal(err)
+		}
 		_ = pkt.ToBytes()
 	}
 }
@@ -131,7 +146,10 @@ func BenchmarkNetflow_UpdateTimeStamp(b *testing.B) {
 	flowCount := 15
 	sourceID := 100
 	session := netflow.NewSession()
-	nf := netflow.GenerateDataNetflow(flowCount, sourceID, srcRange, dstRange, 0, session)
+	nf, err := netflow.GenerateDataNetflow(flowCount, sourceID, srcRange, dstRange, 0, session)
+		if err != nil {
+			b.Fatal(err)
+		}
 	buf := nf.ToBytes()
 	data := buf.Bytes()
 
@@ -150,7 +168,10 @@ func BenchmarkIPFIX_UpdateTimeStamp(b *testing.B) {
 	flowCount := 15
 	sourceID := 100
 	session := netflow.NewSession()
-	pkt := ipfix.GenerateDataIPFIX(flowCount, sourceID, srcRange, dstRange, 0, session)
+	pkt, err := ipfix.GenerateDataIPFIX(flowCount, sourceID, srcRange, dstRange, 0, session)
+		if err != nil {
+			b.Fatal(err)
+		}
 	buf := pkt.ToBytes()
 	data := buf.Bytes()
 
@@ -170,7 +191,10 @@ func BenchmarkValidate_NetFlow_Valid(b *testing.B) {
 	flowCount := 15
 	sourceID := 100
 	session := netflow.NewSession()
-	nf := netflow.GenerateDataNetflow(flowCount, sourceID, srcRange, dstRange, 0, session)
+	nf, err := netflow.GenerateDataNetflow(flowCount, sourceID, srcRange, dstRange, 0, session)
+		if err != nil {
+			b.Fatal(err)
+		}
 	buf := nf.ToBytes()
 	data := buf.Bytes()
 
@@ -188,7 +212,10 @@ func BenchmarkValidate_NetFlow_Invalid(b *testing.B) {
 	flowCount := 15
 	sourceID := 100
 	session := netflow.NewSession()
-	nf := netflow.GenerateDataNetflow(flowCount, sourceID, srcRange, dstRange, 0, session)
+	nf, err := netflow.GenerateDataNetflow(flowCount, sourceID, srcRange, dstRange, 0, session)
+		if err != nil {
+			b.Fatal(err)
+		}
 	buf := nf.ToBytes()
 	data := buf.Bytes()
 
@@ -206,7 +233,10 @@ func BenchmarkValidate_IPFIX_Valid(b *testing.B) {
 	flowCount := 15
 	sourceID := 100
 	session := netflow.NewSession()
-	pkt := ipfix.GenerateDataIPFIX(flowCount, sourceID, srcRange, dstRange, 0, session)
+	pkt, err := ipfix.GenerateDataIPFIX(flowCount, sourceID, srcRange, dstRange, 0, session)
+		if err != nil {
+			b.Fatal(err)
+		}
 	buf := pkt.ToBytes()
 	data := buf.Bytes()
 

--- a/cmd/ipfix_single.go
+++ b/cmd/ipfix_single.go
@@ -76,7 +76,10 @@ func (c *IPFIXCommand) Execute() {
 
 	// Generate and send Data Flows
 	for i := 1; i <= *c.count; i++ {
-		flow := ipfix.GenerateDataIPFIX(10, sourceID, *c.srcRange, *c.dstRange, 0, session)
+		flow, err := ipfix.GenerateDataIPFIX(10, sourceID, *c.srcRange, *c.dstRange, 0, session)
+		if err != nil {
+			log.Fatalf("GenerateDataIPFIX failed: %v", err)
+		}
 		buf := flow.ToBytes()
 		_, err = utils.SendPacket(conn, &net.UDPAddr{IP: destIP, Port: *c.port}, buf.Bytes(), *c.hexDump)
 		if err != nil {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -114,7 +114,10 @@ func sendIPFIX(t *testing.T, port int, count int) {
 
 	// Send data flows
 	for i := 0; i < count; i++ {
-		pkt := ipfix.GenerateDataIPFIX(1, 1, "10.0.0.0/8", "172.16.0.0/12", 0, session)
+		pkt, err := ipfix.GenerateDataIPFIX(1, 1, "10.0.0.0/8", "172.16.0.0/12", 0, session)
+		if err != nil {
+			t.Fatal(err)
+		}
 		pktBuf := pkt.ToBytes()
 		conn.Write(pktBuf.Bytes())
 		time.Sleep(10 * time.Millisecond)

--- a/ipfix/concurrency_padding_test.go
+++ b/ipfix/concurrency_padding_test.go
@@ -76,7 +76,10 @@ func TestDataFlowSet_Padding_Alignment(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			dfs := new(DataFlowSet).Generate(1, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session, tc.profile)
+			dfs, err := new(DataFlowSet).Generate(1, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session, tc.profile)
+			if err != nil {
+				t.Fatal(err)
+			}
 			// Total length should be aligned to 4-byte boundary per RFC 7011
 			if dfs.Length%4 != 0 {
 				t.Errorf("%s: DataFlowSet length %d should be 4-byte aligned",
@@ -162,7 +165,10 @@ func TestGenerateIPFIX_Concurrent_Safe(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			ipfix := GenerateIPFIX(1, 618, "10.0.0.0/8", "10.0.0.0/8", session)
+			ipfix, err := GenerateIPFIX(1, 618, "10.0.0.0/8", "10.0.0.0/8", session)
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			mu.Lock()
 			sequences = append(sequences, ipfix.Header.FlowSequence)
@@ -300,7 +306,10 @@ func TestDataFlowSet_Padding_ZeroFlowCount(t *testing.T) {
 	t.Parallel()
 	session := netflow.NewSession()
 
-	dfs := new(DataFlowSet).Generate(0, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session)
+	dfs, err := new(DataFlowSet).Generate(0, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Even with zero flows, length should be 4-byte aligned
 	if dfs.Length%4 != 0 {

--- a/ipfix/ipfix.go
+++ b/ipfix/ipfix.go
@@ -336,7 +336,7 @@ type DataFlowSet struct {
 
 // Generate creates a DataFlowSet with random flow data.
 // If profile is nil, defaults to GenericIPFIXProfile for backward compatibility.
-func (d *DataFlowSet) Generate(flowCount int, srcRange string, dstRange string, flowSrcPort int, session *netflow.Session, profile ...IPFIXFlowProfile) DataFlowSet {
+func (d *DataFlowSet) Generate(flowCount int, srcRange string, dstRange string, flowSrcPort int, session *netflow.Session, profile ...IPFIXFlowProfile) (DataFlowSet, error) {
 	_ = profile // reserved for future profile-aware data generation
 
 	protoPorts := utils.ProtoPorts
@@ -345,12 +345,11 @@ func (d *DataFlowSet) Generate(flowCount int, srcRange string, dstRange string, 
 	for i := range flowCount {
 		srcIP, err := utils.RandomIPCIDR(srcRange)
 		if err != nil {
-			// Proceed with zero IP on error
-			srcIP = net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+			return DataFlowSet{}, fmt.Errorf("failed to generate src IP for flow %d: %w", i, err)
 		}
 		dstIP, err := utils.RandomIPCIDR(dstRange)
 		if err != nil {
-			dstIP = net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+			return DataFlowSet{}, fmt.Errorf("failed to generate dst IP for flow %d: %w", i, err)
 		}
 		port := flowSrcPort
 		if port == 0 {
@@ -374,7 +373,7 @@ func (d *DataFlowSet) Generate(flowCount int, srcRange string, dstRange string, 
 		Length:    uint16(length),
 		Items:     items,
 		Padding:   padding,
-	}
+	}, nil
 }
 
 // IPFIX is the complete IPFIX export packet structure.
@@ -593,25 +592,31 @@ func GenerateOptionsDataIPFIX(sourceID int, session *netflow.Session) IPFIX {
 }
 
 // GenerateDataIPFIX creates an IPFIX packet containing only data FlowSets.
-func GenerateDataIPFIX(flowCount int, sourceID int, srcRange string, dstRange string, flowSrcPort int, session *netflow.Session) IPFIX {
-	dataFlow := new(DataFlowSet).Generate(flowCount, srcRange, dstRange, flowSrcPort, session)
+func GenerateDataIPFIX(flowCount int, sourceID int, srcRange string, dstRange string, flowSrcPort int, session *netflow.Session) (IPFIX, error) {
+	dataFlow, err := new(DataFlowSet).Generate(flowCount, srcRange, dstRange, flowSrcPort, session)
+	if err != nil {
+		return IPFIX{}, fmt.Errorf("generate data flow set: %w", err)
+	}
 	header := new(Header).Generate(1, sourceID, session)
 	return IPFIX{
 		Header:       header,
 		DataFlowSets: []DataFlowSet{dataFlow},
-	}
+	}, nil
 }
 
 // GenerateIPFIX creates an IPFIX packet containing both template and data FlowSets.
-func GenerateIPFIX(flowCount int, sourceID int, srcRange string, dstRange string, session *netflow.Session) IPFIX {
+func GenerateIPFIX(flowCount int, sourceID int, srcRange string, dstRange string, session *netflow.Session) (IPFIX, error) {
 	templateFlow := new(TemplateFlowSet).Generate(session)
-	dataFlow := new(DataFlowSet).Generate(flowCount, srcRange, dstRange, utils.HTTPSPort, session)
+	dataFlow, err := new(DataFlowSet).Generate(flowCount, srcRange, dstRange, utils.HTTPSPort, session)
+	if err != nil {
+		return IPFIX{}, fmt.Errorf("generate data flow set: %w", err)
+	}
 	header := new(Header).Generate(flowCount+1, sourceID, session)
 	return IPFIX{
 		Header:           header,
 		TemplateFlowSets: []TemplateFlowSet{templateFlow},
 		DataFlowSets:     []DataFlowSet{dataFlow},
-	}
+	}, nil
 }
 
 // size returns the size of the Header in bytes.

--- a/ipfix/ipfix_coverage_test.go
+++ b/ipfix/ipfix_coverage_test.go
@@ -362,7 +362,10 @@ func TestTemplateFlowSet_Size(t *testing.T) {
 func TestDataFlowSet_Size(t *testing.T) {
 	t.Parallel()
 	session := netflow.NewSession()
-	dfs := new(DataFlowSet).Generate(5, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session)
+	dfs, err := new(DataFlowSet).Generate(5, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	size := dfs.size()
 	if size != int(dfs.Length) {
@@ -376,7 +379,10 @@ func TestDataFlowSet_Size(t *testing.T) {
 func TestGetIPFIXSizes(t *testing.T) {
 	t.Parallel()
 	session := netflow.NewSession()
-	flow := GenerateIPFIX(5, 42, "10.0.0.0/8", "10.0.0.0/8", session)
+	flow, err := GenerateIPFIX(5, 42, "10.0.0.0/8", "10.0.0.0/8", session)
+	if err != nil {
+		t.Fatal(err)
+	}
 	s := GetIPFIXSizes(flow)
 
 	if s == "" {
@@ -459,7 +465,10 @@ func TestUpdateTimeStamp_Empty(t *testing.T) {
 func TestUpdateTimeStamp_PreservesPayload(t *testing.T) {
 	t.Parallel()
 	session := netflow.NewSession()
-	flow := GenerateDataIPFIX(3, 42, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session)
+	flow, err := GenerateDataIPFIX(3, 42, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session)
+	if err != nil {
+		t.Fatal(err)
+	}
 	buf := flow.ToBytes()
 	original := buf.Bytes()
 
@@ -570,7 +579,10 @@ func TestOptionsTemplateAndData_RoundTrip(t *testing.T) {
 func TestDataFlowSet_Generate_ZeroFlowCount(t *testing.T) {
 	t.Parallel()
 	session := netflow.NewSession()
-	dfs := new(DataFlowSet).Generate(0, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session)
+	dfs, err := new(DataFlowSet).Generate(0, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if len(dfs.Items) != 0 {
 		t.Errorf("Expected 0 items, got %d", len(dfs.Items))

--- a/ipfix/ipfix_test.go
+++ b/ipfix/ipfix_test.go
@@ -76,7 +76,10 @@ func TestGenerateDataIPFIX(t *testing.T) {
 	flowCount := 10
 	sourceID := 618
 	session := netflow.NewSession()
-	flow := GenerateDataIPFIX(flowCount, sourceID, "10.0.0.0/8", "10.0.0.0/8",	utils.HTTPSPort, session)
+	flow, err := GenerateDataIPFIX(flowCount, sourceID, "10.0.0.0/8", "10.0.0.0/8",	utils.HTTPSPort, session)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if len(flow.DataFlowSets) < 1 {
 		t.Fatal("No data flowsets generated")
@@ -100,7 +103,10 @@ func TestGenerateIPFIX(t *testing.T) {
 	flowCount := 10
 	sourceID := 618
 	session := netflow.NewSession()
-	flow := GenerateIPFIX(flowCount, sourceID, "10.0.0.0/8", "10.0.0.0/8", session)
+	flow, err := GenerateIPFIX(flowCount, sourceID, "10.0.0.0/8", "10.0.0.0/8", session)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if flow.Header.Version != 10 {
 		t.Errorf("Version wrong! Got: %d Want: 10", flow.Header.Version)
@@ -123,7 +129,10 @@ func TestToBytes_RoundTrip(t *testing.T) {
 	session := netflow.NewSession()
 
 	tFlow := GenerateTemplateIPFIX(sourceID, session)
-	dFlow := GenerateDataIPFIX(flowCount, sourceID, "10.0.0.0/8", "10.0.0.0/8",	utils.HTTPSPort, session)
+	dFlow, err := GenerateDataIPFIX(flowCount, sourceID, "10.0.0.0/8", "10.0.0.0/8",	utils.HTTPSPort, session)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	tBuf := tFlow.ToBytes()
 	dBuf := dFlow.ToBytes()
@@ -382,9 +391,18 @@ func TestUpdateTimeStamp(t *testing.T) {
 func TestFlowSequenceMonotonicallyIncreases(t *testing.T) {
 	t.Parallel()
 	session := netflow.NewSession()
-	f1 := GenerateDataIPFIX(1, 42, "10.0.0.0/8", "10.0.0.0/8", 443, session)
-	f2 := GenerateDataIPFIX(1, 42, "10.0.0.0/8", "10.0.0.0/8", 443, session)
-	f3 := GenerateDataIPFIX(1, 42, "10.0.0.0/8", "10.0.0.0/8", 443, session)
+	f1, err := GenerateDataIPFIX(1, 42, "10.0.0.0/8", "10.0.0.0/8", 443, session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f2, err := GenerateDataIPFIX(1, 42, "10.0.0.0/8", "10.0.0.0/8", 443, session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f3, err := GenerateDataIPFIX(1, 42, "10.0.0.0/8", "10.0.0.0/8", 443, session)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if f1.Header.FlowSequence >= f2.Header.FlowSequence {
 		t.Errorf("FlowSequence not monotonically increasing: f1=%d >= f2=%d",
@@ -419,7 +437,10 @@ func TestToBytes_BufferLengthMatchesFlowSetLengths(t *testing.T) {
 	}
 
 	// Test data-only packet
-	dFlow := GenerateDataIPFIX(flowCount, sourceID, "10.0.0.0/8", "10.0.0.0/8",	utils.HTTPSPort, session)
+	dFlow, err := GenerateDataIPFIX(flowCount, sourceID, "10.0.0.0/8", "10.0.0.0/8",	utils.HTTPSPort, session)
+	if err != nil {
+		t.Fatal(err)
+	}
 	dBuf := dFlow.ToBytes()
 	expectedDLen := binary.Size(dFlow.Header)
 	for _, fs := range dFlow.DataFlowSets {
@@ -432,7 +453,10 @@ func TestToBytes_BufferLengthMatchesFlowSetLengths(t *testing.T) {
 	}
 
 	// Test combined packet
-	cFlow := GenerateIPFIX(flowCount, sourceID, "10.0.0.0/8", "10.0.0.0/8", session)
+	cFlow, err := GenerateIPFIX(flowCount, sourceID, "10.0.0.0/8", "10.0.0.0/8", session)
+	if err != nil {
+		t.Fatal(err)
+	}
 	cBuf := cFlow.ToBytes()
 	expectedCLen := binary.Size(cFlow.Header)
 	for _, fs := range cFlow.TemplateFlowSets {
@@ -569,7 +593,10 @@ func TestGenerateDataIPFIX_IPv6(t *testing.T) {
 	flowCount := 10
 	sourceID := 618
 	session := netflow.NewSession()
-	flow := GenerateDataIPFIX(flowCount, sourceID, "2001:db8::/32", "2001:db8::/32",	utils.HTTPSPort, session)
+	flow, err := GenerateDataIPFIX(flowCount, sourceID, "2001:db8::/32", "2001:db8::/32",	utils.HTTPSPort, session)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if len(flow.DataFlowSets) < 1 {
 		t.Fatal("No data flowsets generated")
@@ -612,7 +639,10 @@ func TestGenerateIPFIX_IPv6(t *testing.T) {
 	flowCount := 10
 	sourceID := 618
 	session := netflow.NewSession()
-	flow := GenerateIPFIX(flowCount, sourceID, "2001:db8::/32", "2001:db8::/32", session)
+	flow, err := GenerateIPFIX(flowCount, sourceID, "2001:db8::/32", "2001:db8::/32", session)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if flow.Header.Version != 10 {
 		t.Errorf("Version wrong! Got: %d Want: 10", flow.Header.Version)
@@ -634,7 +664,10 @@ func TestToBytes_IPv6_RoundTrip(t *testing.T) {
 	flowCount := 10
 	session := netflow.NewSession()
 
-	dFlow := GenerateDataIPFIX(flowCount, sourceID, "2001:db8::/32", "2001:db8::/32",	utils.HTTPSPort, session)
+	dFlow, err := GenerateDataIPFIX(flowCount, sourceID, "2001:db8::/32", "2001:db8::/32",	utils.HTTPSPort, session)
+	if err != nil {
+		t.Fatal(err)
+	}
 	dBuf := dFlow.ToBytes()
 
 	// Read back
@@ -699,7 +732,10 @@ func TestToBytes_IPv6_BufferLengthMatchesFlowSetLengths(t *testing.T) {
 	flowCount := 10
 	session := netflow.NewSession()
 
-	dFlow := GenerateDataIPFIX(flowCount, sourceID, "2001:db8::/32", "2001:db8::/32",	utils.HTTPSPort, session)
+	dFlow, err := GenerateDataIPFIX(flowCount, sourceID, "2001:db8::/32", "2001:db8::/32",	utils.HTTPSPort, session)
+	if err != nil {
+		t.Fatal(err)
+	}
 	dBuf := dFlow.ToBytes()
 	expectedDLen := binary.Size(dFlow.Header)
 	for _, fs := range dFlow.DataFlowSets {
@@ -711,7 +747,10 @@ func TestToBytes_IPv6_BufferLengthMatchesFlowSetLengths(t *testing.T) {
 			expectedDLen-binary.Size(dFlow.Header))
 	}
 
-	cFlow := GenerateIPFIX(flowCount, sourceID, "2001:db8::/32", "2001:db8::/32", session)
+	cFlow, err := GenerateIPFIX(flowCount, sourceID, "2001:db8::/32", "2001:db8::/32", session)
+	if err != nil {
+		t.Fatal(err)
+	}
 	cBuf := cFlow.ToBytes()
 	expectedCLen := binary.Size(cFlow.Header)
 	for _, fs := range cFlow.TemplateFlowSets {

--- a/netflow/coverage_test.go
+++ b/netflow/coverage_test.go
@@ -108,7 +108,10 @@ func TestTemplateFlowSet_Padding_Alignment(t *testing.T) {
 func TestDataFlowSet_Size(t *testing.T) {
 	t.Parallel()
 	session := NewSession()
-	dfs := new(DataFlowSet).Generate(10, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session)
+	dfs, err := new(DataFlowSet).Generate(10, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	size := dfs.size()
 	if size <= 0 {
@@ -119,7 +122,10 @@ func TestDataFlowSet_Size(t *testing.T) {
 func TestDataFlowSet_Generate_ZeroFlowCount(t *testing.T) {
 	t.Parallel()
 	session := NewSession()
-	dfs := new(DataFlowSet).Generate(0, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session)
+	dfs, err := new(DataFlowSet).Generate(0, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if len(dfs.Items) != 0 {
 		t.Errorf("expected 0 items with zero flow count, got %d", len(dfs.Items))
@@ -146,7 +152,10 @@ func TestDataFlowSet_Padding_Alignment(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			dfs := new(DataFlowSet).Generate(1, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session, tc.profile)
+			dfs, err := new(DataFlowSet).Generate(1, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session, tc.profile)
+			if err != nil {
+				t.Fatal(err)
+			}
 			// Total length should be aligned to 4-byte boundary
 			if dfs.Length%4 != 0 {
 				t.Errorf("%s: DataFlowSet length %d should be 4-byte aligned",
@@ -165,7 +174,10 @@ func TestGetNetFlowSizes(t *testing.T) {
 	sourceID := 618
 	flowcount := 10
 	session := NewSession()
-	nf := GenerateNetflow(flowcount, sourceID, "10.0.0.0/8", "10.0.0.0/8", session)
+	nf, err := GenerateNetflow(flowcount, sourceID, "10.0.0.0/8", "10.0.0.0/8", session)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	output := GetNetFlowSizes(nf)
 
@@ -342,7 +354,10 @@ func TestToBytes_BufferLengthMatchesFlowSetLengths(t *testing.T) {
 	sourceID := 618
 	flowcount := 10
 	session := NewSession()
-	nf := GenerateNetflow(flowcount, sourceID, "10.0.0.0/8", "10.0.0.0/8", session)
+	nf, err := GenerateNetflow(flowcount, sourceID, "10.0.0.0/8", "10.0.0.0/8", session)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	buf := nf.ToBytes()
 
@@ -365,7 +380,10 @@ func TestToBytes_DataOnly_BufferLengthMatchesFlowSetLengths(t *testing.T) {
 	sourceID := 618
 	flowcount := 10
 	session := NewSession()
-	nf := GenerateDataNetflow(flowcount, sourceID, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session)
+	nf, err := GenerateDataNetflow(flowcount, sourceID, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	buf := nf.ToBytes()
 

--- a/netflow/dataflowset.go
+++ b/netflow/dataflowset.go
@@ -5,7 +5,7 @@ package netflow
 
 import (
 	"encoding/binary"
-	"log"
+	"fmt"
 	"net"
 
 	"github.com/dmabry/flowgre/utils"
@@ -30,7 +30,7 @@ type DataFlowSet struct {
 // Hardcoded TemplateID to 256, but could be variable as long as it is greater than 255.
 // Currently hardcoded to generate random src/dst IPs from 10.0.0.0/8.
 // If profile is nil, defaults to GenericProfile for backward compatibility.
-func (d *DataFlowSet) Generate(flowCount int, srcRange string, dstRange string, flowSrcPort int, session *Session, profile ...FlowProfile) DataFlowSet {
+func (d *DataFlowSet) Generate(flowCount int, srcRange string, dstRange string, flowSrcPort int, session *Session, profile ...FlowProfile) (DataFlowSet, error) {
 	p := FlowProfile(&GenericProfile{}) // default
 	if len(profile) > 0 && profile[0] != nil {
 		p = profile[0]
@@ -43,11 +43,11 @@ func (d *DataFlowSet) Generate(flowCount int, srcRange string, dstRange string, 
 	for i := range flowCount {
 		srcIP, err := utils.RandomIPCIDR(srcRange)
 		if err != nil {
-			log.Printf("Issue generating src IP... proceeding anyway: %v", err)
+			return DataFlowSet{}, fmt.Errorf("failed to generate src IP for flow %d: %w", i, err)
 		}
 		dstIP, err := utils.RandomIPCIDR(dstRange)
 		if err != nil {
-			log.Printf("Issue generating dst IP... proceeding anyway: %v", err)
+			return DataFlowSet{}, fmt.Errorf("failed to generate dst IP for flow %d: %w", i, err)
 		}
 		var flowPort int
 		if flowSrcPort == 0 {
@@ -59,7 +59,7 @@ func (d *DataFlowSet) Generate(flowCount int, srcRange string, dstRange string, 
 	}
 	dataFlowSet.Items = items
 	dataFlowSet.Length = uint16(dataFlowSet.size())
-	return *dataFlowSet
+	return *dataFlowSet, nil
 }
 
 // generateFlow creates a flow record appropriate for the given profile.

--- a/netflow/netflow.go
+++ b/netflow/netflow.go
@@ -14,25 +14,31 @@ import (
 	"github.com/dmabry/flowgre/utils"
 )
 
-func GenerateNetflow(flowCount int, sourceID int, srcRange string, dstRange string, session *Session, profile ...FlowProfile) Netflow {
+func GenerateNetflow(flowCount int, sourceID int, srcRange string, dstRange string, session *Session, profile ...FlowProfile) (Netflow, error) {
 	netflow := new(Netflow)
 	templateFlow := new(TemplateFlowSet).Generate(session, profile...)
-	dataFlow := new(DataFlowSet).Generate(flowCount, srcRange, dstRange, utils.HTTPSPort, session, profile...)
+	dataFlow, err := new(DataFlowSet).Generate(flowCount, srcRange, dstRange, utils.HTTPSPort, session, profile...)
+	if err != nil {
+		return Netflow{}, fmt.Errorf("generate data flow set: %w", err)
+	}
 	header := new(Header).Generate(flowCount+1, sourceID, session) // always +1 of dataflow count, because we are counting the template
 	netflow.Header = header
 	netflow.TemplateFlowSets = append(netflow.TemplateFlowSets, templateFlow)
 	netflow.DataFlowSets = append(netflow.DataFlowSets, dataFlow)
-	return *netflow
+	return *netflow, nil
 }
 
 // GenerateDataNetflow Generates a Netflow containing Data flows
-func GenerateDataNetflow(flowCount int, sourceID int, srcRange string, dstRange string, flowSrcPort int, session *Session, profile ...FlowProfile) Netflow {
+func GenerateDataNetflow(flowCount int, sourceID int, srcRange string, dstRange string, flowSrcPort int, session *Session, profile ...FlowProfile) (Netflow, error) {
 	netflow := new(Netflow)
-	dataFlow := new(DataFlowSet).Generate(flowCount, srcRange, dstRange, flowSrcPort, session, profile...)
+	dataFlow, err := new(DataFlowSet).Generate(flowCount, srcRange, dstRange, flowSrcPort, session, profile...)
+	if err != nil {
+		return Netflow{}, fmt.Errorf("generate data flow set: %w", err)
+	}
 	header := new(Header).Generate(1, sourceID, session) // always 1 for but could be more in future
 	netflow.Header = header
 	netflow.DataFlowSets = append(netflow.DataFlowSets, dataFlow)
-	return *netflow
+	return *netflow, nil
 }
 
 // GenerateTemplateNetflow Generates a Netflow containing Template flow

--- a/netflow/netflow_test.go
+++ b/netflow/netflow_test.go
@@ -66,7 +66,10 @@ func TestGenerateDataNetflow(t *testing.T) {
 	flowcount := 10
 	sourceID := 618
 	session := NewSession()
-	flow := GenerateDataNetflow(flowcount, sourceID, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session)
+	flow, err := GenerateDataNetflow(flowcount, sourceID, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session)
+	if err != nil {
+		t.Fatalf("GenerateDataNetflow failed: %v", err)
+	}
 
 	if len(flow.DataFlowSets) < 1 {
 		t.Errorf("Returned incorrect number of Data Flows! Got: %d Want >: %d", len(flow.DataFlowSets), 1)
@@ -92,7 +95,10 @@ func TestToBytes(t *testing.T) {
 	flowcount := 10
 	session := NewSession()
 	tflow := GenerateTemplateNetflow(sourceID, session)
-	dflow := GenerateDataNetflow(flowcount, sourceID, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session)
+	dflow, err := GenerateDataNetflow(flowcount, sourceID, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session)
+	if err != nil {
+		t.Fatalf("GenerateDataNetflow failed: %v", err)
+	}
 	// Convert to Bytes
 	tbuf := tflow.ToBytes()
 	dbuf := dflow.ToBytes()
@@ -336,7 +342,10 @@ func TestIPv6DataNetflow(t *testing.T) {
 	flowcount := 10
 	sourceID := 618
 	session := NewSession()
-	flow := GenerateDataNetflow(flowcount, sourceID, "2001:db8::/48", "2001:db8:1::/48", utils.HTTPSPort, session)
+	flow, err := GenerateDataNetflow(flowcount, sourceID, "2001:db8::/48", "2001:db8:1::/48", utils.HTTPSPort, session)
+	if err != nil {
+		t.Fatalf("GenerateDataNetflow failed: %v", err)
+	}
 
 	if len(flow.DataFlowSets) < 1 {
 		t.Fatal("expected at least one data flow set")
@@ -371,7 +380,10 @@ func TestIPv6ToBytesRoundTrip(t *testing.T) {
 	flowcount := 5
 	session := NewSession()
 	tflow := GenerateTemplateNetflow(sourceID, session)
-	dflow := GenerateDataNetflow(flowcount, sourceID, "2001:db8::/48", "2001:db8:1::/48", utils.HTTPSPort, session)
+	dflow, err := GenerateDataNetflow(flowcount, sourceID, "2001:db8::/48", "2001:db8:1::/48", utils.HTTPSPort, session)
+	if err != nil {
+		t.Fatalf("GenerateDataNetflow failed: %v", err)
+	}
 
 	// Serialize and deserialize
 	tbuf := tflow.ToBytes()

--- a/netflow/profile_roundtrip_test.go
+++ b/netflow/profile_roundtrip_test.go
@@ -15,7 +15,10 @@ func TestDataFlowSet_Generate_MinimalProfile(t *testing.T) {
 	t.Parallel()
 
 	session := NewSession()
-	dfs := new(DataFlowSet).Generate(5, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session, &MinimalProfile{})
+	dfs, err := new(DataFlowSet).Generate(5, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session, &MinimalProfile{})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if len(dfs.Items) != 5 {
 		t.Fatalf("expected 5 items, got %d", len(dfs.Items))
@@ -40,7 +43,10 @@ func TestDataFlowSet_Generate_ExtendedProfile(t *testing.T) {
 	t.Parallel()
 
 	session := NewSession()
-	dfs := new(DataFlowSet).Generate(5, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session, &ExtendedProfile{})
+	dfs, err := new(DataFlowSet).Generate(5, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session, &ExtendedProfile{})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if len(dfs.Items) != 5 {
 		t.Fatalf("expected 5 items, got %d", len(dfs.Items))
@@ -68,7 +74,10 @@ func TestDataFlowSet_Generate_DefaultProfile(t *testing.T) {
 	t.Parallel()
 
 	session := NewSession()
-	dfs := new(DataFlowSet).Generate(5, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session)
+	dfs, err := new(DataFlowSet).Generate(5, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if len(dfs.Items) != 5 {
 		t.Fatalf("expected 5 items, got %d", len(dfs.Items))
@@ -95,7 +104,10 @@ func TestMinimalProfile_RoundTrip(t *testing.T) {
 
 	// Generate template + data with minimal profile
 	tFlow := GenerateTemplateNetflow(sourceID, session, &MinimalProfile{})
-	dFlow := GenerateDataNetflow(flowCount, sourceID, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session, &MinimalProfile{})
+	dFlow, err := GenerateDataNetflow(flowCount, sourceID, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session, &MinimalProfile{})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Serialize
 	tBuf := tFlow.ToBytes()
@@ -169,7 +181,10 @@ func TestExtendedProfile_RoundTrip(t *testing.T) {
 
 	// Generate template + data with extended profile
 	tFlow := GenerateTemplateNetflow(sourceID, session, &ExtendedProfile{})
-	dFlow := GenerateDataNetflow(flowCount, sourceID, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session, &ExtendedProfile{})
+	dFlow, err := GenerateDataNetflow(flowCount, sourceID, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session, &ExtendedProfile{})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Serialize
 	tBuf := tFlow.ToBytes()
@@ -244,7 +259,10 @@ func TestGenerateNetflow_WithProfile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			session := NewSession()
 
-			nf := GenerateNetflow(5, 1, "10.0.0.0/8", "10.0.0.0/8", session, tc.profile)
+			nf, err := GenerateNetflow(5, 1, "10.0.0.0/8", "10.0.0.0/8", session, tc.profile)
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			if len(nf.TemplateFlowSets) != 1 {
 				t.Fatal("expected 1 template flow set")

--- a/netflow/session_test.go
+++ b/netflow/session_test.go
@@ -10,9 +10,18 @@ import (
 func TestFlowSequenceMonotonicallyIncreases(t *testing.T) {
 	t.Parallel()
 	session := NewSession()
-	f1 := GenerateDataNetflow(1, 42, "10.0.0.0/8", "10.0.0.0/8", 443, session)
-	f2 := GenerateDataNetflow(1, 42, "10.0.0.0/8", "10.0.0.0/8", 443, session)
-	f3 := GenerateDataNetflow(1, 42, "10.0.0.0/8", "10.0.0.0/8", 443, session)
+	f1, err := GenerateDataNetflow(1, 42, "10.0.0.0/8", "10.0.0.0/8", 443, session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f2, err := GenerateDataNetflow(1, 42, "10.0.0.0/8", "10.0.0.0/8", 443, session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f3, err := GenerateDataNetflow(1, 42, "10.0.0.0/8", "10.0.0.0/8", 443, session)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if f1.Header.FlowSequence >= f2.Header.FlowSequence {
 		t.Errorf("FlowSequence not monotonically increasing: f1=%d >= f2=%d", f1.Header.FlowSequence, f2.Header.FlowSequence)
 	}
@@ -25,8 +34,14 @@ func TestFlowSequenceResetsPerSession(t *testing.T) {
 	t.Parallel()
 	s1 := NewSession()
 	s2 := NewSession()
-	f1 := GenerateDataNetflow(1, 42, "10.0.0.0/8", "10.0.0.0/8", 443, s1)
-	f2 := GenerateDataNetflow(1, 42, "10.0.0.0/8", "10.0.0.0/8", 443, s2)
+	f1, err := GenerateDataNetflow(1, 42, "10.0.0.0/8", "10.0.0.0/8", 443, s1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f2, err := GenerateDataNetflow(1, 42, "10.0.0.0/8", "10.0.0.0/8", 443, s2)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if f1.Header.FlowSequence != f2.Header.FlowSequence {
 		t.Errorf("Different sessions should start from same sequence: f1=%d f2=%d", f1.Header.FlowSequence, f2.Header.FlowSequence)
 	}

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -241,7 +241,9 @@ func TestStatsPrinter(t *testing.T) {
 // TestRunIntegration tests the full proxy flow with a single target.
 func TestRunIntegration(t *testing.T) {
 	t.Parallel()
+	origStdout := os.Stdout
 	os.Stdout, _ = os.Open(os.DevNull) // hide logs
+	defer func() { os.Stdout = origStdout }()
 
 	// Start a receiver on target port
 	targetPort := 19997

--- a/record/record_test.go
+++ b/record/record_test.go
@@ -136,7 +136,9 @@ func TestParseFlow(t *testing.T) {
 // TestRunIntegration tests the full record flow.
 func TestRunIntegration(t *testing.T) {
 	t.Parallel()
+	origStdout := os.Stdout
 	os.Stdout, _ = os.Open(os.DevNull) // hide logs
+	defer func() { os.Stdout = origStdout }()
 
 	// Create a temporary directory for the test DB
 	tmpDir := t.TempDir()

--- a/replay/replay_test.go
+++ b/replay/replay_test.go
@@ -174,7 +174,9 @@ func TestWorkerContextCancellation(t *testing.T) {
 // TestRunIntegration tests the full replay flow.
 func TestRunIntegration(t *testing.T) {
 	t.Parallel()
+	origStdout := os.Stdout
 	os.Stdout, _ = os.Open(os.DevNull) // hide logs
+	defer func() { os.Stdout = origStdout }()
 
 	// Create a temporary directory for the test DB
 	tmpDir := t.TempDir()

--- a/single/single.go
+++ b/single/single.go
@@ -73,7 +73,10 @@ func RunCtx(ctx context.Context, collectorIP string, destPort int, srcPort int, 
 			return
 		default:
 		}
-		flow := netflow.GenerateDataNetflow(10, sourceID, srcRange, dstRange, 0, session)
+		flow, err := netflow.GenerateDataNetflow(10, sourceID, srcRange, dstRange, 0, session)
+		if err != nil {
+			log.Fatalf("GenerateDataNetflow failed: %v", err)
+		}
 		buf := flow.ToBytes()
 		fmt.Println(netflow.GetNetFlowSizes(flow))
 		if hexDump {

--- a/single/single_test.go
+++ b/single/single_test.go
@@ -99,7 +99,9 @@ func receiver(ctx context.Context, wg *sync.WaitGroup, ip string, port int, t *t
 // TestRun runs a test to verify functionality.
 func TestRun(t *testing.T) {
 	t.Parallel()
+	origStdout := os.Stdout
 	os.Stdout, _ = os.Open(os.DevNull) // hide all stdout from single
+	defer func() { os.Stdout = origStdout }()
 	wg := &sync.WaitGroup{}
 	ctx, cancel := context.WithCancel(context.Background())
 	sleep := 2 * time.Second


### PR DESCRIPTION
## Changes
- Propagate errors from DataFlowSet.Generate() instead of logging/swallowing
- Fix os.Stdout redirect bug in proxy/record/replay/single tests
- Update 19 files across netflow, ipfix, barrage, single, cmd, and test packages

## Addresses
- C2: Error swallowing in hot path
- M6: Broken coverage reporting