### PR TITLE
docs: replace PendingReleaseNotes reference with GitHub Releases process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,14 +24,12 @@ Send a PR(steps below) to get it into main (2x LGTM applies).
 PR will only be merged when main is open, will be held otherwise until main is open again. 
 No back porting / cherry-picking features to existing branches!
 
-PendingReleaseNotes file
-------------------------
-When developing a new feature or making a (major) change to a existing feature you are encouraged to append this to the PendingReleaseNotes file so that the Release Manager can
-use this file as a source of information when compiling the Release Notes for a new release.
-
-When adding information to the PendingReleaseNotes file make sure that you write a good and understandable description of the new feature or change which you have developed.
-
-Updating the PendingReleaseNotes file is preferably a part of the original Pull Request, but that is up to the developers' discretion.
+Release Notes
+-------------
+Releases are created via GitHub Releases. When tagging a release, include a
+clear description of the changes in the release notes on GitHub. See the
+Release workflow (`.github/workflows/release.yml`) for automated artifact
+building triggered by tag pushes matching `v*`.
 
 Fork the code 
 -------------


### PR DESCRIPTION
## Changes
- Remove reference to nonexistent PendingReleaseNotes file
- Replace with reference to actual release process (GitHub Releases via tag pushes)

## Addresses
- C12: CONTRIBUTING references nonexistent file