### PR TITLE
docs: fix bug report template for CLI tool

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,8 +1,8 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: Report a bug in Flowgre
 title: ''
-labels: ''
+labels: 'bug'
 assignees: ''
 
 ---
@@ -12,27 +12,22 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+1. Run command: `flowgre <subcommand> <flags>`
+2. Observe error/output
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+**Environment**
+- OS: [e.g. Ubuntu 24.04, macOS 14.5, Windows 11]
+- Architecture: [e.g. amd64, arm64]
+- Flowgre version: [output of `flowgre version`]
+- Go version: [output of `go version`]
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
-
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+**Logs / Output**
+```
+Paste relevant output or logs here
+```
 
 **Additional context**
 Add any other context about the problem here.


### PR DESCRIPTION
## Problem

Bug report template contained Desktop/Browser/Smartphone sections irrelevant for a CLI tool (finding L3 from consolidated findings roadmap).

## Fix

Replaced with:
- **Environment** section: OS, architecture, Flowgre version, Go version
- **Reproduction** format: `flowgre <subcommand> <flags>`
- **Logs/Output** block for pasteable diagnostics
- Removed browser/device fields entirely