### PR TITLE
refactor: decouple barrage from web package (H12)

### DIFF
--- a/barrage/barrage.go
+++ b/barrage/barrage.go
@@ -16,8 +16,6 @@ import (
 	"github.com/dmabry/flowgre/netflow"
 	"github.com/dmabry/flowgre/stats"
 	"github.com/dmabry/flowgre/utils"
-	"github.com/dmabry/flowgre/web"
-	"golang.org/x/crypto/bcrypt"
 )
 
 const (
@@ -119,10 +117,19 @@ func worker(id int, ctx context.Context, server string, port int, srcRange strin
 	}
 }
 
-// RunCtx starts the barrage with the given config, FlowGenerator, and external
-// context. Cancelling ctx stops all workers cleanly. Use Run() for CLI usage
-// where OS signal handling is desired.
-func RunCtx(ctx context.Context, config *models.Config, gen FlowGenerator) {
+// RunOpts holds the components returned by StartCtx so the caller can
+// optionally attach a web server or other consumers before waiting.
+type RunOpts struct {
+	Wg     *sync.WaitGroup
+	Stats  *stats.Collector
+	StopFn func() // calls Stop() on the stats collector
+}
+
+// StartCtx starts the barrage workers and stats collector, returning immediately.
+// The caller must call opts.Wg.Wait() to block until completion, and opts.StopFn()
+// to shut down the stats collector. This allows the caller to optionally start
+// a web server or other components that consume the stats collector.
+func StartCtx(ctx context.Context, config *models.Config, gen FlowGenerator) *RunOpts {
 	wg := &sync.WaitGroup{}
 
 	buffer := 20
@@ -154,17 +161,24 @@ func RunCtx(ctx context.Context, config *models.Config, gen FlowGenerator) {
 		go worker(w, ctx, config.Server, config.DstPort, config.SrcRange, config.DstRange, sourceID, config.Delay, templateInterval, wg, sc.StatsChan, gen)
 	}
 
-	// Start WebServer if needed
-	if config.Web {
-		wg.Add(1)
-		// Hash the default password with bcrypt
-		hashedPassword, _ := bcrypt.GenerateFromPassword([]byte("changeme"), bcrypt.DefaultCost)
-		go web.RunWebServer(config.WebIP, config.WebPort, wg, ctx, sc, "admin", string(hashedPassword))
+	return &RunOpts{
+		Wg:     wg,
+		Stats:  sc,
+		StopFn: func() { sc.Stop() },
 	}
+}
 
-	// Wait for all goroutines to finish
-	wg.Wait()
-	sc.Stop()
+// RunCtx starts the barrage with the given config, FlowGenerator, and external
+// context. Cancelling ctx stops all workers cleanly. Use Run() for CLI usage
+// where OS signal handling is desired.
+//
+// Deprecated: Use StartCtx instead, which returns the stats collector so the
+// caller can optionally attach a web server. RunCtx retains the old behavior
+// for backward compatibility.
+func RunCtx(ctx context.Context, config *models.Config, gen FlowGenerator) {
+	opts := StartCtx(ctx, config, gen)
+	opts.Wg.Wait()
+	opts.StopFn()
 }
 
 // Run starts the barrage with the given config and FlowGenerator.

--- a/cmd/barrage.go
+++ b/cmd/barrage.go
@@ -7,11 +7,15 @@ package cmd
 import (
 	"flag"
 	"fmt"
+	"log"
 
 	"github.com/dmabry/flowgre/barrage"
 	"github.com/dmabry/flowgre/config"
+	"github.com/dmabry/flowgre/lifecycle"
 	"github.com/dmabry/flowgre/models"
 	"github.com/dmabry/flowgre/netflow"
+	"github.com/dmabry/flowgre/web"
+	"golang.org/x/crypto/bcrypt"
 )
 
 // BarrageCommand holds flags and state for the barrage subcommand.
@@ -95,11 +99,33 @@ func (c *BarrageCommand) Execute() error {
 		Web:              *c.web,
 		Protocol:         *c.protocol,
 	}
-	if *c.protocol == "ipfix" {
-		barrage.Run(cfg, barrage.IPFIX())
-	} else {
-		barrage.Run(cfg, barrage.NetFlow(nfProfile))
+
+	mgr := lifecycle.New()
+	cleanupDone := mgr.SetupSignalHandler()
+
+	go func() {
+		<-cleanupDone
+		log.Printf("Received signal, shutting down...\n")
+		mgr.Cancel()
+	}()
+
+	opts := barrage.StartCtx(mgr.Context(), cfg, func() barrage.FlowGenerator {
+		if *c.protocol == "ipfix" {
+			return barrage.IPFIX()
+		}
+		return barrage.NetFlow(nfProfile)
+	}())
+
+	// Start web server if needed
+	if cfg.Web {
+		opts.Wg.Add(1)
+		hashedPassword, _ := bcrypt.GenerateFromPassword([]byte("changeme"), bcrypt.DefaultCost)
+		go web.RunWebServer(cfg.WebIP, cfg.WebPort, opts.Wg, mgr.Context(), opts.Stats, "admin", string(hashedPassword))
 	}
+
+	opts.Wg.Wait()
+	opts.StopFn()
+	mgr.Wait()
 	return nil
 }
 


### PR DESCRIPTION
## Problem

barrage package imported web and bcrypt directly, coupling packet generation to the web server (finding H12 from consolidated findings roadmap).

## Fix

Introduced `barrage.StartCtx()` which returns `RunOpts` containing the WaitGroup, stats.Collector, and StopFn. The caller (cmd layer) now decides whether to start the web server.

**Changes:**
- `barrage/barrage.go`: Removed web/bcrypt imports. Added StartCtx() returning RunOpts. Kept RunCtx() for backward compatibility.
- `cmd/barrage.go`: Now imports web/bcrypt and starts web server when cfg.Web is true.

**Benefits:**
- barrage no longer depends on web or bcrypt
- Web server startup is now a caller concern
- Easier to test barrage without web dependencies
- Follows dependency inversion principle