### PR TITLE
fix: use %w for error wrapping (H13)

### DIFF
--- a/cmd/barrage.go
+++ b/cmd/barrage.go
@@ -71,11 +71,11 @@ func (c *BarrageCommand) Execute() error {
 	if *c.configFile != "" {
 		fmt.Println("Reading config file... ignoring any other given arguments")
 		if err := config.InitViper(*c.configFile); err != nil {
-			return fmt.Errorf("error reading config file: %v", err)
+			return fmt.Errorf("error reading config file: %w", err)
 		}
 		cfg, err := config.LoadBarrageConfig()
 		if err != nil {
-			return fmt.Errorf("error loading barrage config: %v", err)
+			return fmt.Errorf("error loading barrage config: %w", err)
 		}
 		if *c.protocol == "ipfix" {
 			barrage.Run(cfg, barrage.IPFIX())

--- a/utils/rand.go
+++ b/utils/rand.go
@@ -24,7 +24,7 @@ func RandStringBytes(n int) string {
 func CryptoRandomNumber(max int64) int64 {
 	n, err := rand.Int(rand.Reader, big.NewInt(max))
 	if err != nil {
-		panic(fmt.Errorf("crypto random failed: %v", err))
+		panic(fmt.Errorf("crypto random failed: %w", err))
 	}
 	return n.Int64()
 }


### PR DESCRIPTION
## Problem

Some fmt.Errorf calls used %v instead of %w, preventing errors.Is/errors.As from unwrapping chains (finding H13 from consolidated findings roadmap).

## Fix

Replaced %v with %w in:
- cmd/barrage.go: config file read/load errors
- utils/rand.go: crypto random panic

All other fmt.Errorf calls already use %w correctly.