### PR TITLE
chore: bump version to 0.6.0 for new major release

### DIFF
--- a/.nfpm/nfpm-alpine-amd64.yaml
+++ b/.nfpm/nfpm-alpine-amd64.yaml
@@ -1,7 +1,7 @@
 name: "flowgre"
 arch: "amd64"
 platform: "linux"
-version: "v0.5.11"
+version: "v0.6.0"
 section: "default"
 priority: "extra"
 provides:
@@ -14,7 +14,7 @@ vendor: "Flowgre Group"
 homepage: "http://github.com/dmabry/flowgre/"
 license: "Apache License 2.0"
 contents:
-- src: ./flowgre_linux_amd64_musl_0.5.11
+- src: ./flowgre_linux_amd64_musl_0.6.0
   dst: /usr/bin/flowgre
   file_info:
     mode: 0755

--- a/.nfpm/nfpm-linux-amd64.yaml
+++ b/.nfpm/nfpm-linux-amd64.yaml
@@ -1,7 +1,7 @@
 name: "flowgre"
 arch: "amd64"
 platform: "linux"
-version: "v0.5.11"
+version: "v0.6.0"
 section: "default"
 priority: "extra"
 provides:
@@ -14,7 +14,7 @@ vendor: "Flowgre Group"
 homepage: "http://github.com/dmabry/flowgre/"
 license: "Apache License 2.0"
 contents:
-- src: ./flowgre_linux_amd64_0.5.11
+- src: ./flowgre_linux_amd64_0.6.0
   dst: /usr/bin/flowgre
   file_info:
     mode: 0755

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 	"github.com/dmabry/flowgre/cmd"
 )
 
-var version = "0.5.15" // semantic version — overridden by -ldflags at build time
+var version = "0.6.0" // semantic version — overridden by -ldflags at build time
 const license = "Apache License, Version 2.0"
 
 func main() {


### PR DESCRIPTION
Prepare release/0.6 branch for v0.6.0 release.

Changes:
- main.go: version 0.5.15 → 0.6.0
- nfpm configs: version 0.5.11 → 0.6.0
- Binary paths updated for 0.6.0