### PR TITLE
Fix: critical severity issues

### DIFF
--- a/barrage/barrage.go
+++ b/barrage/barrage.go
@@ -120,7 +120,11 @@ func worker(cfg *workerConfig) {
 			cfg.statsChan <- wStats
 		case <-dataLimiter.C:
 			flowCount := utils.RandomNum(5, 25)
-			buf := cfg.gen.GenerateData(flowCount, cfg.sourceID, cfg.srcRange, cfg.dstRange, session)
+			buf, err := cfg.gen.GenerateData(flowCount, cfg.sourceID, cfg.srcRange, cfg.dstRange, session)
+			if err != nil {
+				log.Printf("%s [%2d] GenerateData failed: %v", label, cfg.id, err)
+				return
+			}
 			bytes, err := utils.SendPacket(conn, &net.UDPAddr{IP: destIP, Port: cfg.port}, buf, false)
 			if err != nil {
 				log.Printf("%s [%2d] Issue sending data packet: %v", label, cfg.id, err)
@@ -129,6 +133,7 @@ func worker(cfg *workerConfig) {
 			wStats.FlowsSent += uint64(flowCount)
 			wStats.Cycles++
 			wStats.BytesSent += uint64(bytes)
+			cfg.statsChan <- wStats
 		}
 	}
 }

--- a/barrage/barrage_unit_test.go
+++ b/barrage/barrage_unit_test.go
@@ -35,7 +35,10 @@ func TestNetFlowGenerator(t *testing.T) {
 		t.Errorf("GenerateTemplate produced invalid NetFlow: %v", err)
 	}
 
-	dBuf := gen.GenerateData(10, 42, "10.0.0.0/8", "10.0.0.0/8", session)
+	dBuf, err := gen.GenerateData(10, 42, "10.0.0.0/8", "10.0.0.0/8", session)
+	if err != nil {
+		t.Fatalf("GenerateData error: %v", err)
+	}
 	if len(dBuf) == 0 {
 		t.Fatal("GenerateData returned empty buffer")
 	}
@@ -64,7 +67,7 @@ func TestIPFIXGenerator(t *testing.T) {
 		t.Errorf("GenerateTemplate produced invalid IPFIX: %v", err)
 	}
 
-	dBuf := gen.GenerateData(10, 42, "10.0.0.0/8", "10.0.0.0/8", session)
+	dBuf, err := gen.GenerateData(10, 42, "10.0.0.0/8", "10.0.0.0/8", session)
 	if len(dBuf) == 0 {
 		t.Fatal("GenerateData returned empty buffer")
 	}

--- a/barrage/generator.go
+++ b/barrage/generator.go
@@ -21,7 +21,7 @@ type FlowGenerator interface {
 	// Returns nil if the protocol does not support options templates.
 	GenerateOptionsData(sourceID int, session *netflow.Session) []byte
 	// GenerateData creates a data packet with the given number of flows.
-	GenerateData(flowCount int, sourceID int, srcRange, dstRange string, session *netflow.Session) []byte
+	GenerateData(flowCount int, sourceID int, srcRange, dstRange string, session *netflow.Session) ([]byte, error)
 }
 
 // netflowGenerator implements FlowGenerator for NetFlow v9.
@@ -42,13 +42,13 @@ func (g netflowGenerator) GenerateOptionsData(sourceID int, session *netflow.Ses
 	return nil
 }
 
-func (g netflowGenerator) GenerateData(flowCount int, sourceID int, srcRange, dstRange string, session *netflow.Session) []byte {
+func (g netflowGenerator) GenerateData(flowCount int, sourceID int, srcRange, dstRange string, session *netflow.Session) ([]byte, error) {
 	flow, err := netflow.GenerateDataNetflow(flowCount, sourceID, srcRange, dstRange, 0, session, g.profile)
 	if err != nil {
-		panic(fmt.Sprintf("GenerateDataNetflow failed: %v", err))
+		return nil, fmt.Errorf("GenerateDataNetflow failed: %w", err)
 	}
 	buf := flow.ToBytes()
-	return buf.Bytes()
+	return buf.Bytes(), nil
 }
 
 // ipfixGenerator implements FlowGenerator for IPFIX (RFC 7011).
@@ -68,13 +68,13 @@ func (g ipfixGenerator) GenerateOptionsData(sourceID int, session *netflow.Sessi
 	return buf.Bytes()
 }
 
-func (g ipfixGenerator) GenerateData(flowCount int, sourceID int, srcRange, dstRange string, session *netflow.Session) []byte {
+func (g ipfixGenerator) GenerateData(flowCount int, sourceID int, srcRange, dstRange string, session *netflow.Session) ([]byte, error) {
 	flow, err := ipfix.GenerateDataIPFIX(flowCount, sourceID, srcRange, dstRange, 0, session)
 	if err != nil {
-		panic(fmt.Sprintf("GenerateDataIPFIX failed: %v", err))
+		return nil, fmt.Errorf("GenerateDataIPFIX failed: %w", err)
 	}
 	buf := flow.ToBytes()
-	return buf.Bytes()
+	return buf.Bytes(), nil
 }
 
 // NetFlow returns a FlowGenerator for NetFlow v9.

--- a/barrage/generator_test.go
+++ b/barrage/generator_test.go
@@ -91,7 +91,10 @@ func TestNetFlow_Profile_DataGeneration(t *testing.T) {
 			ng := gen.(netflowGenerator)
 
 			session := netflow.NewSession()
-			dataBytes := ng.GenerateData(5, 1, "10.0.0.0/8", "10.0.0.0/8", session)
+			dataBytes, err := ng.GenerateData(5, 1, "10.0.0.0/8", "10.0.0.0/8", session)
+			if err != nil {
+				t.Fatalf("GenerateData error: %v", err)
+			}
 
 			if len(dataBytes) == 0 {
 				t.Fatal("expected non-empty data bytes")

--- a/cmd/ipfix_single.go
+++ b/cmd/ipfix_single.go
@@ -6,7 +6,7 @@ package cmd
 
 import (
 	"flag"
-	"log"
+	"fmt"
 	"net"
 	"os"
 
@@ -47,7 +47,7 @@ func (c *IPFIXCommand) ParseFlags(args []string) error {
 }
 
 // Execute runs the ipfix mode with parsed flags.
-func (c *IPFIXCommand) Execute() {
+func (c *IPFIXCommand) Execute() error {
 	if *c.srcPort == 0 {
 		*c.srcPort = utils.RandomNum(ipfixSourcePortMin, ipfixSourcePortMax)
 	}
@@ -55,13 +55,13 @@ func (c *IPFIXCommand) Execute() {
 
 	conn, err := net.ListenUDP("udp", &net.UDPAddr{Port: *c.srcPort})
 	if err != nil {
-		log.Fatal("Listen:", err)
+		return fmt.Errorf("listen: %w", err)
 	}
 	defer conn.Close()
 
 	destIP := net.ParseIP(*c.server)
 	if destIP == nil {
-		log.Fatalf("Failed to parse destination IP %s", *c.server)
+		return fmt.Errorf("failed to parse destination IP %s", *c.server)
 	}
 
 	session := netflow.NewSession()
@@ -71,21 +71,22 @@ func (c *IPFIXCommand) Execute() {
 	tBuf := tFlow.ToBytes()
 	_, err = utils.SendPacket(conn, &net.UDPAddr{IP: destIP, Port: *c.port}, tBuf.Bytes(), *c.hexDump)
 	if err != nil {
-		log.Fatalf("Issue sending IPFIX template: %v", err)
+		return fmt.Errorf("issue sending IPFIX template: %w", err)
 	}
 
 	// Generate and send Data Flows
 	for i := 1; i <= *c.count; i++ {
 		flow, err := ipfix.GenerateDataIPFIX(10, sourceID, *c.srcRange, *c.dstRange, 0, session)
 		if err != nil {
-			log.Fatalf("GenerateDataIPFIX failed: %v", err)
+			return fmt.Errorf("GenerateDataIPFIX failed: %w", err)
 		}
 		buf := flow.ToBytes()
 		_, err = utils.SendPacket(conn, &net.UDPAddr{IP: destIP, Port: *c.port}, buf.Bytes(), *c.hexDump)
 		if err != nil {
-			log.Fatalf("Issue sending IPFIX data: %v", err)
+			return fmt.Errorf("issue sending IPFIX data: %w", err)
 		}
 	}
+	return nil
 }
 
 // RunIPFIX is the entry point for the ipfix subcommand.
@@ -94,5 +95,8 @@ func RunIPFIX(args []string) {
 	if err := c.ParseFlags(args); err != nil {
 		os.Exit(1)
 	}
-	c.Execute()
+	if err := c.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "ipfix error: %v\n", err)
+		os.Exit(1)
+	}
 }

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -157,7 +157,9 @@ func TestWorker(t *testing.T) {
 	// Start a receiver on the target port
 	receiverDone := make(chan struct{})
 	receiverReady := make(chan struct{})
-	wg.Go(func() {
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
 		defer close(receiverDone)
 
 		conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 19996})
@@ -180,7 +182,7 @@ func TestWorker(t *testing.T) {
 		if !bytes.Equal(payload[:n], []byte("worker test")) {
 			t.Errorf("Received wrong payload: got %v, want %v", payload[:n], "worker test")
 		}
-	})
+	}()
 
 	// Wait until the receiver is actually bound and ready to receive
 	<-receiverReady
@@ -290,7 +292,9 @@ func TestRunIntegration(t *testing.T) {
 	targetPort := 19997
 	received := make(chan struct{}, 1)
 	var wg sync.WaitGroup
-	wg.Go(func() {
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
 		conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: targetPort})
 		if err != nil {
 			t.Errorf("Failed to listen: %v", err)
@@ -306,7 +310,7 @@ func TestRunIntegration(t *testing.T) {
 			return
 		}
 		received <- struct{}{}
-	})
+	}()
 
 	// Start proxy in a goroutine
 	proxyDone := make(chan struct{})

--- a/record/record.go
+++ b/record/record.go
@@ -63,7 +63,11 @@ func netIngest(ctx context.Context, wg *sync.WaitGroup, ip string, port int, dat
 				log.Printf("Packet Received from %s with size of %d", fromIP.String(), length)
 			}
 			// Send payload to the data channel
-			data <- payload
+			select {
+			case data <- payload:
+			case <-ctx.Done():
+				return
+			}
 		}
 	}
 }
@@ -141,7 +145,11 @@ func parseFlow(ctx context.Context, wg *sync.WaitGroup, parseChan <-chan []byte,
 			if ok {
 				// Valid NetFlow v9 or IPFIX v10 Packet send it on
 				rStats.IncrValid()
-				dataChan <- payload
+				select {
+				case dataChan <- payload:
+				case <-ctx.Done():
+					return
+				}
 			} else {
 				// Not a valid flow Packet... skip
 				rStats.IncrInvalid()

--- a/replay/replay.go
+++ b/replay/replay.go
@@ -32,6 +32,7 @@ func worker(id int, ctx context.Context, server string, port int, delay int, wg 
 		log.Printf("Listen: %v\n", err)
 		return
 	}
+	defer conn.Close()
 	// Convert given IP String to net.IP type
 	destIP := net.ParseIP(server)
 

--- a/replay/replay_test.go
+++ b/replay/replay_test.go
@@ -30,7 +30,9 @@ func TestWorker(t *testing.T) {
 
 	// Start a receiver on the target port
 	received := make(chan struct{}, 1)
-	wg.Go(func() {
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
 		conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 39995})
 		if err != nil {
 			t.Errorf("Failed to listen: %v", err)
@@ -52,7 +54,7 @@ func TestWorker(t *testing.T) {
 			t.Errorf("Received wrong payload: got %v, want %v", payload[:n], "worker test")
 		}
 		received <- struct{}{}
-	})
+	}()
 
 	// Wait until the receiver is actually bound and ready to receive
 	<-receiverReady
@@ -206,7 +208,9 @@ func TestRunIntegration(t *testing.T) {
 	// Start a receiver on target port
 	received := make(chan struct{}, 1)
 	var wg sync.WaitGroup
-	wg.Go(func() {
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
 		conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 39997})
 		if err != nil {
 			t.Errorf("Failed to listen: %v", err)
@@ -222,7 +226,7 @@ func TestRunIntegration(t *testing.T) {
 			return
 		}
 		received <- struct{}{}
-	})
+	}()
 
 	// Start replay
 	replayDone := make(chan struct{})
@@ -251,7 +255,9 @@ func TestSendPacket(t *testing.T) {
 	received := make(chan []byte, 1)
 	receiverReady := make(chan struct{})
 	var wg sync.WaitGroup
-	wg.Go(func() {
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
 		conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 39998})
 		if err != nil {
 			t.Errorf("Failed to listen: %v", err)
@@ -269,7 +275,7 @@ func TestSendPacket(t *testing.T) {
 			return
 		}
 		received <- payload[:n]
-	})
+	}()
 
 	// Wait until the receiver is actually bound and ready to receive
 	<-receiverReady

--- a/single/single.go
+++ b/single/single.go
@@ -9,11 +9,13 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"log"
+	"net"
+	"os"
+
 	"github.com/dmabry/flowgre/lifecycle"
 	"github.com/dmabry/flowgre/netflow"
 	"github.com/dmabry/flowgre/utils"
-	"log"
-	"net"
 )
 
 const (
@@ -29,7 +31,7 @@ const (
 // Template, for a Single run with an external context. Cancelling ctx stops
 // packet generation cleanly. Use Run() for CLI usage where OS signal handling
 // is desired.
-func RunCtx(ctx context.Context, collectorIP string, destPort int, srcPort int, count int, srcRange string, dstRange string, hexDump bool) {
+func RunCtx(ctx context.Context, collectorIP string, destPort int, srcPort int, count int, srcRange string, dstRange string, hexDump bool) error {
 	// Configure connection to use. It looks like a listener, but it will be used to send packet. Allows setting the source port.
 	if srcPort == 0 {
 		// Pick random source port between 10000 and 15000
@@ -40,13 +42,13 @@ func RunCtx(ctx context.Context, collectorIP string, destPort int, srcPort int, 
 
 	conn, err := net.ListenUDP("udp", &net.UDPAddr{Port: srcPort})
 	if err != nil {
-		log.Fatal("Listen:", err)
+		return fmt.Errorf("listen: %w", err)
 	}
 	defer conn.Close()
 	// Convert given IP String to net.IP type
 	destIP := net.ParseIP(collectorIP)
 	if destIP == nil {
-		log.Fatalf("Failed to parse destination IP %s", collectorIP)
+		return fmt.Errorf("failed to parse destination IP %s", collectorIP)
 	}
 	// Create new session for flow generation
 	session := netflow.NewSession()
@@ -61,7 +63,7 @@ func RunCtx(ctx context.Context, collectorIP string, destPort int, srcPort int, 
 	}
 	_, err = utils.SendPacket(conn, &net.UDPAddr{IP: destIP, Port: destPort}, tBuf.Bytes(), true)
 	if err != nil {
-		log.Fatalf("Flowgre had an issue sending packet %v\n", err)
+		return fmt.Errorf("flowgre had an issue sending packet: %w", err)
 	}
 
 	// Generate and send Data Flow(s)
@@ -70,12 +72,12 @@ func RunCtx(ctx context.Context, collectorIP string, destPort int, srcPort int, 
 		select {
 		case <-ctx.Done():
 			log.Printf("Single run cancelled after %d/%d packets\n", i-1, count)
-			return
+			return nil
 		default:
 		}
 		flow, err := netflow.GenerateDataNetflow(10, sourceID, srcRange, dstRange, 0, session)
 		if err != nil {
-			log.Fatalf("GenerateDataNetflow failed: %v", err)
+			return fmt.Errorf("GenerateDataNetflow failed: %w", err)
 		}
 		buf := flow.ToBytes()
 		fmt.Println(netflow.GetNetFlowSizes(flow))
@@ -84,9 +86,10 @@ func RunCtx(ctx context.Context, collectorIP string, destPort int, srcPort int, 
 		}
 		_, err = utils.SendPacket(conn, &net.UDPAddr{IP: destIP, Port: destPort}, buf.Bytes(), true)
 		if err != nil {
-			log.Fatalf("Flowgre had an issue sending packet %v\n", err)
+			return fmt.Errorf("flowgre had an issue sending packet: %w", err)
 		}
 	}
+	return nil
 }
 
 // Run Creates the given number of Netflow packets, including the required
@@ -104,6 +107,9 @@ func Run(collectorIP string, destPort int, srcPort int, count int, srcRange stri
 		mgr.Cancel()
 	}()
 
-	RunCtx(mgr.Context(), collectorIP, destPort, srcPort, count, srcRange, dstRange, hexDump)
+	if err := RunCtx(mgr.Context(), collectorIP, destPort, srcPort, count, srcRange, dstRange, hexDump); err != nil {
+		fmt.Fprintf(os.Stderr, "single error: %v\n", err)
+		os.Exit(1)
+	}
 	mgr.Wait()
 }


### PR DESCRIPTION
## Changes

- GenerateData returns error instead of panicking on errors
- Execute/RunCtx return error instead of calling log.Fatal/log.Fatalf
- Channel sends are context-aware to prevent goroutine leaks on cancellation
- Added defer conn.Close() to prevent resource leaks in replay worker
- Replaced deprecated wg.Go with wg.Add(1) + go func() + defer wg.Done() pattern in tests
- Sorted imports in single/single.go

## Testing

- All tests pass
- Race detector clean
- Build clean