### PR TITLE
Fix: Test stability - flaky tests and go vet violations

### DIFF
--- a/ipfix/concurrency_padding_test.go
+++ b/ipfix/concurrency_padding_test.go
@@ -160,6 +160,7 @@ func TestGenerateIPFIX_Concurrent_Safe(t *testing.T) {
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 	sequences := make([]uint32, 0, numGoroutines)
+	errCh := make(chan error, numGoroutines)
 
 	for i := 0; i < numGoroutines; i++ {
 		wg.Add(1)
@@ -167,7 +168,8 @@ func TestGenerateIPFIX_Concurrent_Safe(t *testing.T) {
 			defer wg.Done()
 			ipfix, err := GenerateIPFIX(1, 618, "10.0.0.0/8", "10.0.0.0/8", session)
 			if err != nil {
-				t.Fatal(err)
+				errCh <- err
+				return
 			}
 
 			mu.Lock()
@@ -177,6 +179,11 @@ func TestGenerateIPFIX_Concurrent_Safe(t *testing.T) {
 	}
 
 	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		t.Fatal(err)
+	}
 
 	// Verify all sequences are unique
 	seen := make(map[uint32]bool)

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -146,13 +146,19 @@ func TestReplicator(t *testing.T) {
 
 // TestWorker tests that workers can send packets to a target.
 func TestWorker(t *testing.T) {
-	t.Parallel()
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	workerChan := make(chan []byte, bufferSize)
 	var wg sync.WaitGroup
+
+	// Bind to port 0 to get a free port
+	probe, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatalf("Failed to find free port: %v", err)
+	}
+	port := probe.LocalAddr().(*net.UDPAddr).Port
+	probe.Close()
 
 	// Start a receiver on the target port
 	receiverDone := make(chan struct{})
@@ -162,7 +168,7 @@ func TestWorker(t *testing.T) {
 		defer wg.Done()
 		defer close(receiverDone)
 
-		conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 19996})
+		conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: port})
 		if err != nil {
 			t.Errorf("Failed to listen: %v", err)
 			return
@@ -189,7 +195,7 @@ func TestWorker(t *testing.T) {
 
 	// Start worker
 	wg.Add(1)
-	go worker(1, ctx, "127.0.0.1", 19996, &wg, workerChan)
+	go worker(1, ctx, "127.0.0.1", port, &wg, workerChan)
 
 	// Send test payload
 	workerChan <- []byte("worker test")
@@ -283,14 +289,28 @@ func TestStatsPrinter(t *testing.T) {
 
 // TestRunIntegration tests the full proxy flow with a single target.
 func TestRunIntegration(t *testing.T) {
-	t.Parallel()
 	origStdout := os.Stdout
 	os.Stdout, _ = os.Open(os.DevNull) // hide logs
 	defer func() { os.Stdout = origStdout }()
 
+	// Bind to ports 0 to get free ports
+	probe1, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatalf("Failed to find free port: %v", err)
+	}
+	targetPort := probe1.LocalAddr().(*net.UDPAddr).Port
+	probe1.Close()
+
+	probe2, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatalf("Failed to find free port: %v", err)
+	}
+	proxyPort := probe2.LocalAddr().(*net.UDPAddr).Port
+	probe2.Close()
+
 	// Start a receiver on target port
-	targetPort := 19997
 	received := make(chan struct{}, 1)
+	receiverReady := make(chan struct{})
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
@@ -302,6 +322,8 @@ func TestRunIntegration(t *testing.T) {
 		}
 		defer conn.Close()
 
+		close(receiverReady) // signal that the receiver is listening
+
 		payload := make([]byte, udpMaxBufferSize)
 		conn.SetReadDeadline(time.Now().Add(10 * time.Second))
 		_, _, err = conn.ReadFromUDP(payload)
@@ -312,18 +334,44 @@ func TestRunIntegration(t *testing.T) {
 		received <- struct{}{}
 	}()
 
+	// Wait for receiver to be ready
+	select {
+	case <-receiverReady:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timeout waiting for receiver to start")
+	}
+
 	// Start proxy in a goroutine
 	proxyDone := make(chan struct{})
 	go func() {
 		defer close(proxyDone)
-		Run("127.0.0.1", 19998, false, []string{"127.0.0.1:19997"})
+		Run("127.0.0.1", proxyPort, false, []string{"127.0.0.1:" + strconv.Itoa(targetPort)})
 	}()
 
-	// Give proxy time to start
-	time.Sleep(1 * time.Second)
+	// Wait for proxy to be ready
+	proxyReady := make(chan struct{})
+	go func() {
+		for {
+			c, err := net.DialUDP("udp", nil, &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: proxyPort})
+			if err == nil {
+				c.Close()
+				close(proxyReady)
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+	select {
+	case <-proxyReady:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timeout waiting for proxy to start")
+	}
+
+	// Allow proxy goroutines to fully initialize after port is bound
+	time.Sleep(100 * time.Millisecond)
 
 	// Send a test packet to the proxy
-	conn, err := net.DialUDP("udp", nil, &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 19998})
+	conn, err := net.DialUDP("udp", nil, &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: proxyPort})
 	if err != nil {
 		t.Fatalf("Failed to dial: %v", err)
 	}

--- a/record/record_test.go
+++ b/record/record_test.go
@@ -17,23 +17,44 @@ import (
 
 // TestNetIngest tests that the network listener can receive UDP packets.
 func TestNetIngest(t *testing.T) {
-	t.Parallel()
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	dataChan := make(chan []byte, 1024)
 	var wg sync.WaitGroup
 
-	// Start netIngest
-	wg.Add(1)
-	go netIngest(ctx, &wg, "127.0.0.1", 29995, dataChan, false)
+	// Bind to port 0 to get a free port, then pass it to netIngest
+	probe, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatalf("Failed to find free port: %v", err)
+	}
+	port := probe.LocalAddr().(*net.UDPAddr).Port
+	probe.Close()
 
-	// Give listener time to start
-	time.Sleep(100 * time.Millisecond)
+	wg.Add(1)
+	go netIngest(ctx, &wg, "127.0.0.1", port, dataChan, false)
+
+	// Wait for the listener to be ready by probing the port
+	ready := make(chan struct{})
+	go func() {
+		for {
+			c, err := net.DialUDP("udp", nil, &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: port})
+			if err == nil {
+				c.Close()
+				close(ready)
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+	select {
+	case <-ready:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timeout waiting for listener to start")
+	}
 
 	// Send a test packet
-	conn, err := net.DialUDP("udp", nil, &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 29995})
+	conn, err := net.DialUDP("udp", nil, &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: port})
 	if err != nil {
 		t.Fatalf("Failed to dial: %v", err)
 	}
@@ -72,14 +93,15 @@ func TestDbIngest(t *testing.T) {
 	tmpDir := t.TempDir()
 	dataChan := make(chan []byte, 1024)
 
+	done := make(chan struct{})
 	var wg sync.WaitGroup
 	wg.Add(1)
-	go dbIngest(ctx, &wg, tmpDir, dataChan, false)
+	go func() {
+		defer close(done)
+		dbIngest(ctx, &wg, tmpDir, dataChan, false)
+	}()
 
-	// Give DB time to open
-	time.Sleep(200 * time.Millisecond)
-
-	// Send test payload
+	// Send test payload; dbIngest will process it once the DB is open
 	testPayload := []byte("test db ingest payload")
 	dataChan <- testPayload
 
@@ -89,6 +111,7 @@ func TestDbIngest(t *testing.T) {
 	// Cleanup
 	cancel()
 	wg.Wait()
+	<-done
 	close(dataChan)
 }
 
@@ -135,7 +158,6 @@ func TestParseFlow(t *testing.T) {
 
 // TestRunIntegration tests the full record flow.
 func TestRunIntegration(t *testing.T) {
-	t.Parallel()
 	origStdout := os.Stdout
 	os.Stdout, _ = os.Open(os.DevNull) // hide logs
 	defer func() { os.Stdout = origStdout }()
@@ -151,9 +173,17 @@ func TestRunIntegration(t *testing.T) {
 	parseChan := make(chan []byte, 1024)
 	var wg sync.WaitGroup
 
+	// Bind to port 0 to get a free port
+	probe, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatalf("Failed to find free port: %v", err)
+	}
+	port := probe.LocalAddr().(*net.UDPAddr).Port
+	probe.Close()
+
 	// Start netIngest
 	wg.Add(1)
-	go netIngest(ctx, &wg, "127.0.0.1", 29996, parseChan, false)
+	go netIngest(ctx, &wg, "127.0.0.1", port, parseChan, false)
 
 	// Start parseFlow
 	wg.Add(1)
@@ -163,11 +193,27 @@ func TestRunIntegration(t *testing.T) {
 	wg.Add(1)
 	go dbIngest(ctx, &wg, tmpDir, dataChan, false)
 
-	// Give components time to start
-	time.Sleep(1 * time.Second)
+	// Wait for the listener to be ready
+	ready := make(chan struct{})
+	go func() {
+		for {
+			c, err := net.DialUDP("udp", nil, &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: port})
+			if err == nil {
+				c.Close()
+				close(ready)
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+	select {
+	case <-ready:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timeout waiting for listener to start")
+	}
 
 	// Send a valid NetFlow packet to the recorder
-	conn, err := net.DialUDP("udp", nil, &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 29996})
+	conn, err := net.DialUDP("udp", nil, &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: port})
 	if err != nil {
 		t.Fatalf("Failed to dial: %v", err)
 	}
@@ -200,12 +246,17 @@ func TestNetIngestContextCancellation(t *testing.T) {
 	dataChan := make(chan []byte, 1024)
 	var wg sync.WaitGroup
 
+	// Bind to port 0 to get a free port
+	probe, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatalf("Failed to find free port: %v", err)
+	}
+	port := probe.LocalAddr().(*net.UDPAddr).Port
+	probe.Close()
+
 	// Start netIngest
 	wg.Add(1)
-	go netIngest(ctx, &wg, "127.0.0.1", 29997, dataChan, false)
-
-	// Give listener time to start
-	time.Sleep(100 * time.Millisecond)
+	go netIngest(ctx, &wg, "127.0.0.1", port, dataChan, false)
 
 	// Cancel context
 	cancel()
@@ -239,9 +290,6 @@ func TestDbIngestContextCancellation(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go dbIngest(ctx, &wg, tmpDir, dataChan, false)
-
-	// Give DB time to open
-	time.Sleep(200 * time.Millisecond)
 
 	// Cancel context
 	cancel()

--- a/replay/replay_test.go
+++ b/replay/replay_test.go
@@ -19,8 +19,6 @@ import (
 
 // TestWorker tests that workers can send packets to a target.
 func TestWorker(t *testing.T) {
-	t.Parallel()
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -28,12 +26,20 @@ func TestWorker(t *testing.T) {
 	receiverReady := make(chan struct{})
 	var wg sync.WaitGroup
 
+	// Bind to port 0 to get a free port
+	probe, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatalf("Failed to find free port: %v", err)
+	}
+	port := probe.LocalAddr().(*net.UDPAddr).Port
+	probe.Close()
+
 	// Start a receiver on the target port
 	received := make(chan struct{}, 1)
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 39995})
+		conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: port})
 		if err != nil {
 			t.Errorf("Failed to listen: %v", err)
 			return
@@ -61,7 +67,7 @@ func TestWorker(t *testing.T) {
 
 	// Start worker
 	wg.Add(1)
-	go worker(1, ctx, "127.0.0.1", 39995, 100, &wg, false, dataChan)
+	go worker(1, ctx, "127.0.0.1", port, 100, &wg, false, dataChan)
 
 	// Send test payload
 	dataChan <- []byte("worker test")
@@ -146,12 +152,17 @@ func TestWorkerContextCancellation(t *testing.T) {
 	dataChan := make(chan []byte, 1024)
 	var wg sync.WaitGroup
 
+	// Bind to port 0 to get a free port
+	probe, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatalf("Failed to find free port: %v", err)
+	}
+	port := probe.LocalAddr().(*net.UDPAddr).Port
+	probe.Close()
+
 	// Start worker
 	wg.Add(1)
-	go worker(1, ctx, "127.0.0.1", 39996, 100, &wg, false, dataChan)
-
-	// Give worker time to start
-	time.Sleep(100 * time.Millisecond)
+	go worker(1, ctx, "127.0.0.1", port, 100, &wg, false, dataChan)
 
 	// Cancel context
 	cancel()
@@ -175,7 +186,6 @@ func TestWorkerContextCancellation(t *testing.T) {
 
 // TestRunIntegration tests the full replay flow.
 func TestRunIntegration(t *testing.T) {
-	t.Parallel()
 	origStdout := os.Stdout
 	os.Stdout, _ = os.Open(os.DevNull) // hide logs
 	defer func() { os.Stdout = origStdout }()
@@ -205,13 +215,21 @@ func TestRunIntegration(t *testing.T) {
 	}
 	db.Close()
 
+	// Bind to port 0 to get a free port
+	probe, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatalf("Failed to find free port: %v", err)
+	}
+	port := probe.LocalAddr().(*net.UDPAddr).Port
+	probe.Close()
+
 	// Start a receiver on target port
 	received := make(chan struct{}, 1)
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 39997})
+		conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: port})
 		if err != nil {
 			t.Errorf("Failed to listen: %v", err)
 			return
@@ -232,7 +250,7 @@ func TestRunIntegration(t *testing.T) {
 	replayDone := make(chan struct{})
 	go func() {
 		defer close(replayDone)
-		Run("127.0.0.1", 39997, 100, tmpDir, false, 1, false, false)
+		Run("127.0.0.1", port, 100, tmpDir, false, 1, false, false)
 	}()
 
 	// Wait for packet to be received
@@ -249,16 +267,23 @@ func TestRunIntegration(t *testing.T) {
 
 // TestSendPacket verifies that SendPacket works correctly.
 func TestSendPacket(t *testing.T) {
-	t.Parallel()
-
 	// Start a receiver
 	received := make(chan []byte, 1)
 	receiverReady := make(chan struct{})
 	var wg sync.WaitGroup
+
+	// Bind to port 0 to get a free port
+	probe, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatalf("Failed to find free port: %v", err)
+	}
+	port := probe.LocalAddr().(*net.UDPAddr).Port
+	probe.Close()
+
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 39998})
+		conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: port})
 		if err != nil {
 			t.Errorf("Failed to listen: %v", err)
 			return
@@ -290,7 +315,7 @@ func TestSendPacket(t *testing.T) {
 
 	testPayload := []byte("test send packet")
 
-	_, err = utils.SendPacket(conn, &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 39998}, testPayload, false)
+	_, err = utils.SendPacket(conn, &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: port}, testPayload, false)
 	if err != nil {
 		t.Fatalf("Failed to send: %v", err)
 	}

--- a/single/single_test.go
+++ b/single/single_test.go
@@ -7,12 +7,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
-	"github.com/dmabry/flowgre/netflow"
 	"net"
 	"os"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/dmabry/flowgre/netflow"
 )
 
 const udpMaxBufferSize = 65507
@@ -98,18 +99,26 @@ func receiver(ctx context.Context, wg *sync.WaitGroup, ip string, port int, t *t
 
 // TestRun runs a test to verify functionality.
 func TestRun(t *testing.T) {
-	t.Parallel()
 	origStdout := os.Stdout
 	os.Stdout, _ = os.Open(os.DevNull) // hide all stdout from single
 	defer func() { os.Stdout = origStdout }()
+
+	// Bind to port 0 to get a free port
+	probe, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatalf("Failed to find free port: %v", err)
+	}
+	port := probe.LocalAddr().(*net.UDPAddr).Port
+	probe.Close()
+
 	wg := &sync.WaitGroup{}
 	ctx, cancel := context.WithCancel(context.Background())
 	sleep := 2 * time.Second
 	// Start receiver
 	wg.Add(1)
-	go receiver(ctx, wg, "127.0.0.1", 9997, t)
+	go receiver(ctx, wg, "127.0.0.1", port, t)
 	// Run single
-	Run("127.0.0.1", 9997, 9999, 10, "10.10.10.0/28", "10.11.11.0/28", false)
+	Run("127.0.0.1", port, 9999, 10, "10.10.10.0/28", "10.11.11.0/28", false)
 	// Sleep for longer than expected duration
 	time.Sleep(sleep)
 	cancel()


### PR DESCRIPTION
## Summary

Fixes test stability issues identified during code review:

### Issues Fixed

1. **go vet violation** — `t.Fatal` called from goroutine in `ipfix/concurrency_padding_test.go:170` (undefined behavior per Go docs)
2. **Flaky `TestNetIngest`** — Hardcoded `time.Sleep(100ms)` unreliable under `-race` detector; caused "Timeout waiting for packet" failures  
3. **Flaky `TestRun`** — Fixed port `9997` with `t.Parallel()` caused "address already in use" collisions

### Changes

- **ipfix/concurrency_padding_test.go**: Replace `t.Fatal` in goroutine with error channel pattern
- **record/record_test.go**: Dynamic port allocation (port 0), port probe readiness, remove hardcoded sleeps
- **single/single_test.go**: Dynamic port allocation, remove `t.Parallel()`
- **replay/replay_test.go**: Dynamic port allocation, remove `t.Parallel()` from network tests
- **proxy/proxy_test.go**: Dynamic port allocation, receiver-ready channel, remove `t.Parallel()` from integration test

### Verification

- `go vet ./...` — clean (previously 1 violation)
- `go build` — clean
- `go test -race ./... -count=1` — all 13 packages pass, 3 consecutive runs stable
