### PR TITLE
Fix: barrage YAML settings, zero template interval, release packaging, web credentials, and README

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+      VERSION: "${{ github.ref_name }}"
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -27,15 +28,30 @@ jobs:
 
     - name: Build multi-platform
       run: |
-        bash ./scripts/build-multiplatform.sh ${GITHUB_REF#refs/tags/v}
+        bash ./scripts/build-multiplatform.sh "${{ env.VERSION }}"
 
     - name: List built files
       run: |
         ls -l flowgre_*
 
+    - name: Verify expected binaries
+      run: |
+        for bin in \
+          flowgre_linux_amd64_${{ env.VERSION }} \
+          flowgre_linux_arm64_${{ env.VERSION }} \
+          flowgre_darwin_amd64_${{ env.VERSION }} \
+          flowgre_darwin_arm64_${{ env.VERSION }} \
+          flowgre_windows_amd64_${{ env.VERSION }} \
+          flowgre_windows_arm64_${{ env.VERSION }}; do
+          if [ ! -f "$bin" ]; then
+            echo "ERROR: Expected binary not found: $bin"
+            exit 1
+          fi
+        done
+
     - name: Build musl version
       run: |
-        CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -ldflags '-s -w -X main.version=${GITHUB_REF#refs/tags/v}' -o flowgre_linux_amd64_musl_${GITHUB_REF#refs/tags/v}
+        CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -ldflags "-s -w -X main.version=${{ env.VERSION }}" -o flowgre_linux_amd64_musl_${{ env.VERSION }}
 
     - name: Install nfpm
       run: |
@@ -46,16 +62,14 @@ jobs:
 
     - name: Package RPM and DEB
       env:
-        VERSION: "${{ github.ref_name }}"
-        BINARY: "./flowgre_linux_amd64_${{ github.ref_name }}"
+        BINARY: "./flowgre_linux_amd64_${{ env.VERSION }}"
       run: |
         nfpm package -p rpm -f ./.nfpm/nfpm-linux-amd64.yaml
         nfpm package -p deb -f ./.nfpm/nfpm-linux-amd64.yaml
 
     - name: Package APK
       env:
-        VERSION: "${{ github.ref_name }}"
-        BINARY: "./flowgre_linux_amd64_musl_${{ github.ref_name }}"
+        BINARY: "./flowgre_linux_amd64_musl_${{ env.VERSION }}"
       run: |
         nfpm package -p apk -f ./.nfpm/nfpm-alpine-amd64.yaml
 
@@ -64,7 +78,7 @@ jobs:
         mkdir -p ./bin
         TRIVY_VERSION="v0.70.0"
         curl -sSfL https://github.com/aquasecurity/trivy/releases/download/${TRIVY_VERSION}/trivy_${TRIVY_VERSION#v}_Linux-64bit.tar.gz | tar xz && mv trivy ./bin/
-        ./bin/trivy fs --format cyclonedx --output sbom_${GITHUB_REF#refs/tags/v}.json .
+        ./bin/trivy fs --format cyclonedx --output sbom_${{ env.VERSION }}.json .
 
     - name: Create GitHub Release
       uses: softprops/action-gh-release@26994186c0ac3ef5cae75ac16aa32e8153525f77
@@ -74,6 +88,6 @@ jobs:
           flowgre_*
           flowgre-*
           sbom_*
-        body: "Flowgre, version ${{ github.ref_name }}"
-        name: "${{ github.ref_name }}"
+        body: "Flowgre, version ${{ env.VERSION }}"
+        name: "${{ env.VERSION }}"
         prerelease: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 ## Build / Lint / Test Commands
 - `go build` – compile the binary.
+- `gofmt -l .` – list files with formatting issues (run after every code change).
+- `gofmt -w .` – auto-format all Go files.
 - `go test -v ./... -count 1` – run all tests once, verbose output.
 - `go test -race ./...` – run tests with race detector.
 - `GOEXPERIMENT=goroutineleakprofile go test ./...` – verify no goroutine leaks (Go 1.26+).
@@ -16,7 +18,7 @@
 - Constants: UpperCamelCase or UPPERCASE if global.
 - Errors returned as `fmt.Errorf("...")`; wrap errors with context.
 - Use `go vet`, `staticcheck`, `golangci‑lint` for static analysis.
-- Formatting: run `gofmt -w .` before commit.
+- Formatting: run `gofmt -l .` after every code change to verify formatting, then `gofmt -w .` to fix any issues.
 - Documentation: comment every exported function and type.
 
 ## CI / GitHub Actions

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Flowgre
 
 Slinging packets since 2022!
@@ -7,9 +6,9 @@ Slinging packets since 2022!
     ___ _
   / __\ | _____      ____ _ _ __ ___
  / _\ | |/ _ \ \ /\ / / _` | '__/ _ \
-/ /   | | (_) \ V  V / (_| | | |  __/
-\/    |_|\___/ \_/\_/ \__, |_|  \___|
-                      |___/
+ / /   | | (_) \ V  V / (_| | | |  __/
+ \/    |_|\___/ \_/\_/ \__, |_|  \___|
+                       |___/
 ```
 
 For sending fabricated NetFlow v9 and IPFIX (RFC 7011) traffic to a collector for testing. Supports both IPv4 and IPv6 flow records with auto-detection from CIDR ranges.
@@ -72,8 +71,10 @@ Source: [`cmd/barrage.go`](cmd/barrage.go)
 | `-template-interval` | int | `30` | Seconds between template retransmissions (`0` to disable) |
 | `-config` | string | *(empty)* | Path to a YAML config file. Supersedes all other flags when provided |
 | `-web` | bool | `false` | Enable the web dashboard server |
-| `-web-ip` | string | `0.0.0.0` | IP address the web server listens on (IPv4 or IPv6) |
+| `-web-ip` | string | `127.0.0.1` | IP address the web server listens on (IPv4 or IPv6) |
 | `-web-port` | int | `8080` | Port to bind the web server on |
+| `-web-username` | string | *(empty)* | Web server username (falls back to `FLOWGRE_WEB_USERNAME` env var, then `admin`) |
+| `-web-password` | string | *(empty)* | Web server password (falls back to `FLOWGRE_WEB_PASSWORD` env var) |
 | `-protocol` | string | `netflow` | Protocol to use: `netflow` or `ipfix` |
 | `-profile` | string | `generic` | NetFlow flow profile: `generic`, `minimal`, or `extended` |
 
@@ -168,8 +169,10 @@ targets:
     src-range: "10.0.0.0/8"      # CIDR range for source IPs
     dst-range: "10.0.0.0/8"      # CIDR range for destination IPs
     web: false                    # Enable web dashboard
-    web-ip: "0.0.0.0"            # Web server listen address
+    web-ip: "127.0.0.1"          # Web server listen address (default: loopback)
     web-port: 8080               # Web server port
+    web-username: ""             # Web server username (or use FLOWGRE_WEB_USERNAME env var)
+    web-password: ""             # Web server password (or use FLOWGRE_WEB_PASSWORD env var)
     protocol: "netflow"          # Protocol: "netflow" or "ipfix"
 ```
 
@@ -185,191 +188,19 @@ targets:
 | `src-range` | string | `10.0.0.0/8` | `-src-range` | CIDR notation for source IP pool (auto-detects IPv4 vs IPv6) |
 | `dst-range` | string | `10.0.0.0/8` | `-dst-range` | CIDR notation for destination IP pool (auto-detects IPv4 vs IPv6) |
 | `web` | bool | `false` | `-web` | Enable the built-in web dashboard |
-| `web-ip` | string | `0.0.0.0` | `-web-ip` | Bind address for the web dashboard (IPv4/IPv6) |
+| `web-ip` | string | `127.0.0.1` | `-web-ip` | Bind address for the web dashboard (IPv4/IPv6). Defaults to loopback for safety |
 | `web-port` | int | `8080` | `-web-port` | Listening port for the web dashboard |
+| `web-username` | string | *(empty)* | `-web-username` | Web dashboard username. Falls back to `FLOWGRE_WEB_USERNAME` env var. Defaults to `admin` |
+| `web-password` | string | *(empty)* | `-web-password` | Web dashboard password. Falls back to `FLOWGRE_WEB_PASSWORD` env var. If omitted, a random password is generated and printed at startup |
 | `protocol` | string | `netflow` | `-protocol` | Export protocol: `netflow` (NetFlow v9) or `ipfix` (IPFIX/RFC 7011) |
 
 Note: The `profile` flag (`-profile`) has **no config file equivalent** — it is only available via the CLI for the `barrage` subcommand and controls the NetFlow field set (`generic`, `minimal`, `extended`).
 
 Note: The `updatets` flag (`-updatets`) has **no config file equivalent** — it is only available via the CLI for the `replay` subcommand.
 
+Note: When binding the web dashboard to a non-loopback address (e.g., `0.0.0.0`), explicit credentials are required via CLI flags, YAML config, or environment variables. Startup will fail otherwise.
+
 ---
-
-## Single Mode
-
-## Build / Lint / Test Commands
-- `go build` – compile the binary.
-- `go test -v ./... -count 1` – run all tests once, verbose output.
-- `go test -race ./...` – run tests with race detector.
-- `GOEXPERIMENT=goroutineleakprofile go test ./...` – verify no goroutine leaks (Go 1.26+).
-- `golangci-lint run` – linting (requires golangci‑lint installed).
-- `gosec ./...` – security scan.
-- `trivy fs .` – container image scanning.
-
-## Code Style Guidelines
-- Imports sorted alphabetically; group standard library first.
-- Use `context.Context` for cancellation and timeouts.
-- Exported names: PascalCase; unexported: lowerCamelCase.
-- Constants: UpperCamelCase or UPPERCASE if global.
-- Errors returned as `fmt.Errorf("...")`; wrap errors with context.
-- Use `go vet`, `staticcheck`, `golangci-lint` for static analysis.
-- Formatting: run `gofmt -w .` before commit.
-- Documentation: comment every exported function and type.
-
-## CI / GitHub Actions
-The project uses the following GitHub actions:
-- **Go Tests** (`.github/workflows/go-test.yml`) – runs tests on push to main and pull requests.
-  - Steps include checkout, Go setup, `go mod tidy`, test run (`go test -v ./... -count 1`), and build.
-- **Auto‑Merge Dependabot** (`.github/workflows/auto-merge-dependabot.yml`) – merges Dependabot PRs automatically.
-- **Release** (`.github/workflows/release.yml`) – builds release artifacts for multiple platforms.
-  - Triggered on tag pushes matching `v*` pattern.
-  - Automatically updates nfpm configs at runtime using `sed`.
-  - Creates packages for RPM, DEB, APK, and standalone binaries.
-  - Generates SBOM using Trivy v0.70.0.
-- **Security Scan** (`.github/workflows/security.yml`) – runs `trivy` to scan images.
-
-Ensure that any new CI configuration follows the pattern above and includes relevant steps.
-
-## Environment Variables & Configuration
-The project uses Viper for configuration handling (`https://github.com/spf13/viper`).
-Command‑line arguments, YAML config files, and environment variables are supported.
-If you need to supply environment variables, create a `.env` file in the repository root (e.g., `export FLOWGRE_DEBUG=1`) or set them directly when running commands.
-
-Dependencies which read environment variables include `github.com/subosito/gotenv`. Use `gotenv.Load()` in your code as needed.
-
-## Go Version Requirement
-- **Required:** Go 1.26 or later (latest stable).
-- Install from https://go.dev/dl/ or use `go env -w GOTOOLCHAIN=auto`.
-- Experimental features available: `goroutineleakprofile`, `simd`, `runtimesecret`.
-
-## Dependency Management
-- Keep dependencies minimal and use standard library packages where possible.
-- Run `go mod tidy` before building/testing to remove unused modules.
-- Use `go get -u` for updating dependencies when necessary, but always check the changelog.
-- **Security:** Address Dependabot alerts promptly by updating vulnerable dependencies.
-- Current known issues: None (all alerts resolved as of v0.5.14).
-
-## Testing Practices
-- Write tests in `_test.go` files.
-- Run tests with race detector: `go test -race ./...`.
-- Ensure coverage is adequate; run `go test -coverprofile=coverage.out` and generate reports if required.
-- Include integration tests where applicable (e.g., `netflow_test.go`, `record_test.go`, etc.).
-- All tests must pass before merging PRs or creating releases.
-
-## Branching Strategy
-
-### Main Branch
-- `main` is the primary development branch.
-- All features should be developed in feature branches off `main`.
-- PRs must pass all CI checks before merging.
-
-### Feature Branches
-- Naming: `feature/<description>` or `fix/<description>`
-- Created from: `main`
-- Target: Merge back to `main` via PR
-- Example: `git checkout -b feature/my-feature main`
-
-### Release Branches
-- Naming: `release/<major>.<minor>` (e.g., `release/0.5`)
-- Created from: `main` when starting a new release cycle
-- Purpose: Long-lived branch for patch releases (e.g., v0.5.1, v0.5.2)
-- Hotfixes can be applied to this branch and merged back to `main`
-- Example: `git checkout -b release/0.5 main`
-
-### Release Tags
-- Naming: `v<major>.<minor>.<patch>` (e.g., `v0.5.15`)
-- Created from: Release branch (e.g., `release/0.5`)
-- Pushing a tag triggers the Release workflow automatically
-- Example:
-  ```bash
-  git checkout release/0.5
-  git tag v0.5.15
-  git push origin v0.5.15
-  ```
-
-## PR Template / Commit Messages
-Use the provided pull request template in `.github/ISSUE_TEMPLATE/feature_request.md`. Commit messages should be concise, describing *why* the change was made:
-```
-Add: [Feature] – brief description of new feature
-Fix: [Bug] – description of bug fixed
-Update: [Enhancement] – details of improvement
-```
-
-## Release Workflow Details
-The Release workflow (`.github/workflows/release.yml`) performs the following steps:
-1. **Checkout code** – Pull the repository at the tagged commit.
-2. **Set up Go** – Install Go 1.26.
-3. **Install build dependencies** – Install build-essential.
-4. **Build multi-platform** – Run `scripts/build-multiplatform.sh` with the version.
-5. **List built files** – Verify all binaries were created.
-6. **Update nfpm configs** – Dynamically update version and binary paths using `sed`.
-7. **Build musl version** – Build Alpine-compatible binary.
-8. **Install nfpm** – Install package manager tool.
-9. **Package RPM and DEB** – Create Linux packages.
-10. **Package APK** – Create Alpine package.
-11. **Generate SBOM** – Create Software Bill of Materials using Trivy.
-12. **Create GitHub Release** – Upload all artifacts to GitHub.
-
-**Important:** The nfpm config update step is critical. It ensures the config files match the actual binary names generated during the build.
-
-### Common Workflows
-
-### Creating a Feature Branch
-```bash
-git checkout main
-git pull origin main
-git checkout -b feature/my-feature
-# Make changes, commit, push
-git push -u origin feature/my-feature
-```
-
-### Creating a Release
-```bash
-# Create release branch if not exists
-git checkout main
-git pull origin main
-git checkout -b release/0.5  # Or use existing branch
-
-# Create and push tag
-git tag v0.5.15
-git push origin v0.5.15
-
-# Monitor CI at https://github.com/dmabry/flowgre/actions
-```
-
-### Hotfixing a Release
-```bash
-# Make changes on release branch
-git checkout release/0.5
-# Fix issue, commit
-git commit -m "Fix: Critical bug fix"
-
-# Create new patch tag
-git tag v0.5.16
-git push origin v0.5.16
-
-# Merge fix back to main
-git checkout main
-git merge release/0.5
-git push origin main
-```
-
-### Addressing Dependabot Alerts
-```bash
-# Create branch for security fix
-git checkout -b security/fix-vulnerability main
-
-# Update vulnerable dependency
-go get <package>@<new-version>
-go mod tidy
-
-# Test thoroughly
-go test -v ./... -count 1
-
-# Create PR and merge
-git push -u origin security/fix-vulnerability
-# Create PR on GitHub
-```
 
 ## Single Mode
 
@@ -430,12 +261,18 @@ Usage of flowgre barrage:
         protocol to use: netflow or ipfix (default "netflow")
   -profile string
         flow profile for netflow: generic, minimal, extended (default "generic")
+  -template-interval int
+        seconds between template retransmissions (default 30, 0 to disable)
   -web
         Whether to use the web server or not
   -web-ip string
-        IP address the web server will listen on (default "0.0.0.0")
+        IP address the web server will listen on (default "127.0.0.1")
   -web-port int
         Port to bind the web server on (default 8080)
+  -web-username string
+        Web server username (default: env FLOWGRE_WEB_USERNAME or "admin")
+  -web-password string
+        Web server password (default: env FLOWGRE_WEB_PASSWORD or generated)
   -workers int
         number of workers to create. Unique sources per worker (default 4)
 ```
@@ -578,6 +415,10 @@ Usage of flowgre proxy:
 ## Web Dashboard
 
 Flowgre provides a basic web dashboard that will display the number of workers, how much work they've done and the config used to start Flowgre. The stats shown all come from the stats collector and should match the stdout worker stats.
+
+The web dashboard defaults to binding on `127.0.0.1` (loopback) for security. When binding to a non-loopback address, explicit credentials are required via CLI flags, YAML config, or environment variables (`FLOWGRE_WEB_USERNAME`/`FLOWGRE_WEB_PASSWORD`).
+
+If no credentials are provided, a random password is generated and printed at startup. Basic Authentication should be placed behind TLS when used across an untrusted network.
 
 ![Dashboard Image](https://github.com/dmabry/flowgre/blob/main/docs/images/dashboard.png?raw=true)
 

--- a/barrage/barrage.go
+++ b/barrage/barrage.go
@@ -98,9 +98,11 @@ func worker(cfg *workerConfig) {
 	// Template retransmission ticker — fires every templateInterval seconds.
 	// When templateInterval is 0, no ticker is created so templates are never retransmitted.
 	var tmplTicker *time.Ticker
+	var tmplChan <-chan time.Time
 	if cfg.templateInterval > 0 {
 		tmplTicker = time.NewTicker(time.Duration(cfg.templateInterval) * time.Second)
 		defer tmplTicker.Stop()
+		tmplChan = tmplTicker.C
 	}
 
 	for {
@@ -108,7 +110,7 @@ func worker(cfg *workerConfig) {
 		case <-cfg.ctx.Done():
 			log.Printf("%s [%2d] Exiting due to signal\n", label, cfg.id)
 			return
-		case <-tmplTicker.C:
+		case <-tmplChan:
 			// Retransmit template every templateInterval seconds
 			bytes, err := utils.SendPacket(conn, &net.UDPAddr{IP: destIP, Port: cfg.port}, tBuf, false)
 			if err != nil {
@@ -169,12 +171,6 @@ func StartCtx(ctx context.Context, config *models.Config, gen FlowGenerator) *Ru
 	wg.Add(1)
 	go sc.Run(wg, ctx)
 
-	// Default template retransmission interval is 30 seconds if not set
-	templateInterval := config.TemplateInterval
-	if templateInterval <= 0 {
-		templateInterval = 30
-	}
-
 	// Start up the workers
 	wg.Add(config.Workers)
 	for w := 1; w <= config.Workers; w++ {
@@ -188,7 +184,7 @@ func StartCtx(ctx context.Context, config *models.Config, gen FlowGenerator) *Ru
 			dstRange:         config.DstRange,
 			sourceID:         sourceID,
 			delay:            config.Delay,
-			templateInterval: templateInterval,
+			templateInterval: config.TemplateInterval,
 			wg:               wg,
 			statsChan:        sc.StatsChan,
 			gen:              gen,

--- a/cmd/barrage.go
+++ b/cmd/barrage.go
@@ -8,6 +8,8 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"net"
+	"os"
 
 	"github.com/dmabry/flowgre/barrage"
 	"github.com/dmabry/flowgre/config"
@@ -33,6 +35,8 @@ type BarrageCommand struct {
 	web              *bool
 	protocol         *string
 	profile          *string
+	webUsername      *string
+	webPassword      *string
 }
 
 // ParseFlags parses command-line flags for the barrage mode.
@@ -51,55 +55,178 @@ func (c *BarrageCommand) ParseFlags(args []string) error {
 	c.web = fs.Bool("web", false, "Whether to use the web server or not")
 	c.protocol = fs.String("protocol", "netflow", "protocol to use: netflow or ipfix")
 	c.profile = fs.String("profile", "generic", "flow profile: generic, minimal, extended")
+	c.webUsername = fs.String("web-username", "", "Web server username (default: env FLOWGRE_WEB_USERNAME or generated)")
+	c.webPassword = fs.String("web-password", "", "Web server password (default: env FLOWGRE_WEB_PASSWORD or generated)")
 	return fs.Parse(args)
+}
+
+// resolveProfile returns the FlowProfile for the given profile string.
+func resolveProfile(profile string) netflow.FlowProfile {
+	switch profile {
+	case "minimal":
+		return &netflow.MinimalProfile{}
+	case "extended":
+		return &netflow.ExtendedProfile{}
+	default:
+		return &netflow.GenericProfile{}
+	}
+}
+
+// validateProtocol returns an error if the protocol is not supported.
+func validateProtocol(protocol string) error {
+	switch protocol {
+	case "netflow", "ipfix":
+		return nil
+	default:
+		return fmt.Errorf("unsupported protocol %q: must be netflow or ipfix", protocol)
+	}
+}
+
+// resolveCredentials returns the username and hashed password for the web server.
+// It checks CLI flags, then environment variables, then generates a random password.
+func resolveCredentials(cliUsername, cliPassword string) (string, string, error) {
+	username := cliUsername
+	if username == "" {
+		username = os.Getenv("FLOWGRE_WEB_USERNAME")
+	}
+	if username == "" {
+		username = "admin"
+	}
+
+	password := cliPassword
+	if password == "" {
+		password = os.Getenv("FLOWGRE_WEB_PASSWORD")
+	}
+
+	if password == "" {
+		var err error
+		password, err = web.GenerateRandomPassword(16)
+		if err != nil {
+			return "", "", fmt.Errorf("generate random web password: %w", err)
+		}
+		log.Printf("Generated random web password: %s", password)
+	}
+
+	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		return "", "", fmt.Errorf("generate web password hash: %w", err)
+	}
+
+	return username, string(hashedPassword), nil
+}
+
+// effectiveWebIP returns the effective web IP address, defaulting empty string to loopback.
+func effectiveWebIP(webIP string) string {
+	if webIP == "" {
+		return "127.0.0.1"
+	}
+	return webIP
+}
+
+// validateTemplateInterval returns an error if the interval is negative.
+func validateTemplateInterval(interval int) error {
+	if interval < 0 {
+		return fmt.Errorf("template-interval must be 0 (disabled) or a positive value, got %d", interval)
+	}
+	return nil
+}
+
+// validateWebBinding checks that the web server binding is safe.
+// Non-loopback addresses require explicit credentials.
+func validateWebBinding(webIP, cliUsername, cliPassword string) error {
+	effective := effectiveWebIP(webIP)
+
+	ip := net.ParseIP(effective)
+	if ip == nil {
+		return fmt.Errorf("invalid web-ip address: %s", effective)
+	}
+
+	// Loopback addresses are always safe
+	if ip.IsLoopback() {
+		return nil
+	}
+
+	// Non-loopback requires explicit credentials
+	hasExplicitCreds := cliUsername != "" || cliPassword != "" ||
+		os.Getenv("FLOWGRE_WEB_USERNAME") != "" || os.Getenv("FLOWGRE_WEB_PASSWORD") != ""
+
+	if !hasExplicitCreds {
+		return fmt.Errorf("binding web server to non-loopback address %s requires explicit credentials via --web-username/--web-password or FLOWGRE_WEB_USERNAME/FLOWGRE_WEB_PASSWORD environment variables", effective)
+	}
+
+	return nil
 }
 
 // Execute runs the barrage mode with parsed flags.
 func (c *BarrageCommand) Execute() error {
-	// Resolve profile from string
-	var nfProfile netflow.FlowProfile
-	switch *c.profile {
-	case "minimal":
-		nfProfile = &netflow.MinimalProfile{}
-	case "extended":
-		nfProfile = &netflow.ExtendedProfile{}
-	default:
-		nfProfile = &netflow.GenericProfile{}
-	}
+	var cfg *models.Config
 
-	// If config file is provided, load from it and ignore other args
+	// Load configuration from file or CLI flags
 	if *c.configFile != "" {
 		fmt.Println("Reading config file... ignoring any other given arguments")
 		if err := config.InitViper(*c.configFile); err != nil {
 			return fmt.Errorf("error reading config file: %w", err)
 		}
-		cfg, err := config.LoadBarrageConfig()
+		var err error
+		cfg, err = config.LoadBarrageConfig()
 		if err != nil {
 			return fmt.Errorf("error loading barrage config: %w", err)
 		}
-		if *c.protocol == "ipfix" {
-			barrage.Run(cfg, barrage.IPFIX())
-		} else {
-			barrage.Run(cfg, barrage.NetFlow(nfProfile))
+	} else {
+		cfg = &models.Config{
+			Server:           *c.server,
+			DstPort:          *c.port,
+			SrcRange:         *c.srcRange,
+			DstRange:         *c.dstRange,
+			Delay:            *c.delay,
+			TemplateInterval: *c.templateInterval,
+			Workers:          *c.workers,
+			WebIP:            *c.webIP,
+			WebPort:          *c.webPort,
+			Web:              *c.web,
+			Protocol:         *c.protocol,
+			WebUsername:      *c.webUsername,
+			WebPassword:      *c.webPassword,
 		}
-		return nil
 	}
 
-	// Run with command-line args
-	cfg := &models.Config{
-		Server:           *c.server,
-		DstPort:          *c.port,
-		SrcRange:         *c.srcRange,
-		DstRange:         *c.dstRange,
-		Delay:            *c.delay,
-		TemplateInterval: *c.templateInterval,
-		Workers:          *c.workers,
-		WebIP:            *c.webIP,
-		WebPort:          *c.webPort,
-		Web:              *c.web,
-		Protocol:         *c.protocol,
+	// Validate protocol
+	if err := validateProtocol(cfg.Protocol); err != nil {
+		return err
 	}
 
+	// Validate template interval
+	if err := validateTemplateInterval(cfg.TemplateInterval); err != nil {
+		return err
+	}
+
+	// Validate web binding safety
+	if cfg.Web {
+		if err := validateWebBinding(cfg.WebIP, cfg.WebUsername, cfg.WebPassword); err != nil {
+			return err
+		}
+	}
+
+	// Resolve credentials BEFORE starting workers so errors fail fast
+	var webUsername, webHashedPassword string
+	if cfg.Web {
+		var err error
+		webUsername, webHashedPassword, err = resolveCredentials(cfg.WebUsername, cfg.WebPassword)
+		if err != nil {
+			return fmt.Errorf("resolve web credentials: %w", err)
+		}
+	}
+
+	// Select generator based on protocol
+	var gen barrage.FlowGenerator
+	if cfg.Protocol == "ipfix" {
+		gen = barrage.IPFIX()
+	} else {
+		nfProfile := resolveProfile(*c.profile)
+		gen = barrage.NetFlow(nfProfile)
+	}
+
+	// Setup lifecycle and signal handling
 	mgr := lifecycle.New()
 	cleanupDone := mgr.SetupSignalHandler()
 
@@ -109,18 +236,14 @@ func (c *BarrageCommand) Execute() error {
 		mgr.Cancel()
 	}()
 
-	opts := barrage.StartCtx(mgr.Context(), cfg, func() barrage.FlowGenerator {
-		if *c.protocol == "ipfix" {
-			return barrage.IPFIX()
-		}
-		return barrage.NetFlow(nfProfile)
-	}())
+	// Start barrage workers
+	opts := barrage.StartCtx(mgr.Context(), cfg, gen)
 
 	// Start web server if needed
 	if cfg.Web {
 		opts.Wg.Add(1)
-		hashedPassword, _ := bcrypt.GenerateFromPassword([]byte("changeme"), bcrypt.DefaultCost)
-		go web.RunWebServer(cfg.WebIP, cfg.WebPort, opts.Wg, mgr.Context(), opts.Stats, "admin", string(hashedPassword))
+		effectiveIP := effectiveWebIP(cfg.WebIP)
+		go web.RunWebServer(effectiveIP, cfg.WebPort, opts.Wg, mgr.Context(), opts.Stats, webUsername, webHashedPassword)
 	}
 
 	opts.Wg.Wait()

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -4,7 +4,10 @@
 package cmd
 
 import (
+	"os"
 	"testing"
+
+	"github.com/dmabry/flowgre/web"
 )
 
 // =============================================================================
@@ -745,5 +748,232 @@ func TestRunProxy(t *testing.T) {
 	}
 	if *c.ip != "127.0.0.1" || *c.port != 9995 {
 		t.Error("flags not parsed correctly")
+	}
+}
+
+// =============================================================================
+// Validation tests
+// =============================================================================
+
+func TestValidateProtocol(t *testing.T) {
+	tests := []struct {
+		name    string
+		proto   string
+		wantErr bool
+	}{
+		{"netflow", "netflow", false},
+		{"ipfix", "ipfix", false},
+		{"invalid", "sflow", true},
+		{"empty", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateProtocol(tt.proto)
+			if tt.wantErr && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateWebBinding(t *testing.T) {
+	tests := []struct {
+		name    string
+		webIP   string
+		cliUser string
+		cliPass string
+		envUser string
+		envPass string
+		wantErr bool
+	}{
+		{"loopback safe", "127.0.0.1", "", "", "", "", false},
+		{"ipv6 loopback safe", "::1", "", "", "", "", false},
+		{"non-loopback with cli creds", "0.0.0.0", "admin", "secret", "", "", false},
+		{"non-loopback with env creds", "0.0.0.0", "", "", "admin", "secret", false},
+		{"non-loopback no creds", "0.0.0.0", "", "", "", "", true},
+		{"non-loopback cli user only", "192.168.1.1", "admin", "", "", "", false},
+		{"non-loopback cli pass only", "192.168.1.1", "", "secret", "", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envUser != "" {
+				os.Setenv("FLOWGRE_WEB_USERNAME", tt.envUser)
+				defer os.Unsetenv("FLOWGRE_WEB_USERNAME")
+			}
+			if tt.envPass != "" {
+				os.Setenv("FLOWGRE_WEB_PASSWORD", tt.envPass)
+				defer os.Unsetenv("FLOWGRE_WEB_PASSWORD")
+			}
+			err := validateWebBinding(tt.webIP, tt.cliUser, tt.cliPass)
+			if tt.wantErr && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestResolveCredentials(t *testing.T) {
+	// Test CLI credentials
+	username, hashed, err := resolveCredentials("myuser", "mypass")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if username != "myuser" {
+		t.Errorf("expected username 'myuser', got %q", username)
+	}
+	if hashed == "" {
+		t.Error("expected non-empty hashed password for CLI credentials")
+	}
+
+	// Test environment variable credentials
+	os.Setenv("FLOWGRE_WEB_USERNAME", "envuser")
+	os.Setenv("FLOWGRE_WEB_PASSWORD", "envpass")
+	envUsername, envHashed, err := resolveCredentials("", "")
+	if err != nil {
+		os.Unsetenv("FLOWGRE_WEB_USERNAME")
+		os.Unsetenv("FLOWGRE_WEB_PASSWORD")
+		t.Fatalf("unexpected error: %v", err)
+	}
+	os.Unsetenv("FLOWGRE_WEB_USERNAME")
+	os.Unsetenv("FLOWGRE_WEB_PASSWORD")
+	if envUsername != "envuser" {
+		t.Errorf("expected username 'envuser', got %q", envUsername)
+	}
+	if envHashed == "" {
+		t.Error("expected non-empty hashed password for env credentials")
+	}
+
+	// Test default credentials (random password generated)
+	defUsername, defHashed, err := resolveCredentials("", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if defUsername != "admin" {
+		t.Errorf("expected default username 'admin', got %q", defUsername)
+	}
+	if defHashed == "" {
+		t.Error("expected non-empty hashed password for default credentials")
+	}
+}
+
+func TestResolveProfile(t *testing.T) {
+	tests := []struct {
+		name     string
+		profile  string
+		expected string
+	}{
+		{"generic", "generic", "generic"},
+		{"minimal", "minimal", "minimal"},
+		{"extended", "extended", "extended"},
+		{"unknown", "unknown", "generic"},
+		{"empty", "", "generic"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			profile := resolveProfile(tt.profile)
+			name := profile.Name()
+			if name != tt.expected {
+				t.Errorf("expected name %q, got %q", tt.expected, name)
+			}
+		})
+	}
+}
+
+func TestGenerateRandomPassword(t *testing.T) {
+	password, err := web.GenerateRandomPassword(16)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(password) != 16 {
+		t.Errorf("expected length 16, got %d", len(password))
+	}
+
+	// Generate two passwords and verify they differ (probabilistic)
+	p1, err := web.GenerateRandomPassword(32)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	p2, err := web.GenerateRandomPassword(32)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p1 == p2 {
+		t.Log("Warning: two random passwords are identical (extremely unlikely)")
+	}
+}
+
+func TestEffectiveWebIP(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"empty defaults to loopback", "", "127.0.0.1"},
+		{"loopback unchanged", "127.0.0.1", "127.0.0.1"},
+		{"non-loopback unchanged", "0.0.0.0", "0.0.0.0"},
+		{"ipv6 loopback unchanged", "::1", "::1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := effectiveWebIP(tt.input)
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestValidateWebBindingEmptyIP(t *testing.T) {
+	// Empty web-ip should be treated as loopback (safe)
+	err := validateWebBinding("", "", "")
+	if err != nil {
+		t.Errorf("empty web-ip should be safe (defaults to loopback), got error: %v", err)
+	}
+}
+
+func TestValidateTemplateInterval(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   int
+		wantErr bool
+	}{
+		{"zero disabled", 0, false},
+		{"positive", 30, false},
+		{"negative", -1, true},
+		{"large negative", -100, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateTemplateInterval(tt.value)
+			if tt.wantErr && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestBarrageCommandNegativeTemplateInterval(t *testing.T) {
+	c := &BarrageCommand{}
+	args := []string{"-template-interval", "-1"}
+	if err := c.ParseFlags(args); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	err := c.Execute()
+	if err == nil {
+		t.Error("expected error for negative template-interval")
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -65,10 +65,12 @@ func LoadBarrageConfig() (*models.Config, error) {
 	srcRange := getString(targetValues, "src-range", "10.0.0.0/8")
 	dstRange := getString(targetValues, "dst-range", "10.0.0.0/8")
 	templateInterval := getInt(targetValues, "template-interval", 30)
-	webIP := getString(targetValues, "web-ip", "0.0.0.0")
+	webIP := getString(targetValues, "web-ip", "127.0.0.1")
 	webPort := getInt(targetValues, "web-port", 8080)
 	web := getBool(targetValues, "web", false)
 	protocol := getString(targetValues, "protocol", "netflow")
+	webUsername := getString(targetValues, "web-username", "")
+	webPassword := getString(targetValues, "web-password", "")
 
 	log.Printf("target: %s ip: %s port: %d workers: %d delay: %d template-interval: %d src-range: %s dst-range: %s web: %v web-ip: %s web-port: %d protocol: %s\n",
 		targetName, ip, port, workers, delay, templateInterval, srcRange, dstRange, web, webIP, webPort, protocol)
@@ -85,6 +87,8 @@ func LoadBarrageConfig() (*models.Config, error) {
 		WebPort:          webPort,
 		Web:              web,
 		Protocol:         protocol,
+		WebUsername:      webUsername,
+		WebPassword:      webPassword,
 	}, nil
 }
 

--- a/models/models.go
+++ b/models/models.go
@@ -19,6 +19,8 @@ type Config struct {
 	WebPort          int    `json:"web_port,omitempty"`
 	Web              bool   `json:"web,omitempty"`
 	Protocol         string `json:"protocol,omitempty"` // "netflow" or "ipfix"
+	WebUsername      string `json:"web_username,omitempty"`
+	WebPassword      string `json:"web_password,omitempty"`
 }
 
 type WorkerStat struct {

--- a/web/web.go
+++ b/web/web.go
@@ -7,10 +7,13 @@ package web
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/subtle"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"log"
+	"math/big"
 	"net/http"
 	"strconv"
 	"strings"
@@ -21,6 +24,21 @@ import (
 	"github.com/dmabry/flowgre/stats"
 	"golang.org/x/crypto/bcrypt"
 )
+
+const passwordCharset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*"
+
+// GenerateRandomPassword generates a cryptographically secure random password of the given length.
+func GenerateRandomPassword(length int) (string, error) {
+	result := make([]byte, length)
+	for i := range result {
+		idx, err := rand.Int(rand.Reader, big.NewInt(int64(len(passwordCharset))))
+		if err != nil {
+			return "", fmt.Errorf("generate random byte: %w", err)
+		}
+		result[i] = passwordCharset[idx.Int64()]
+	}
+	return string(result), nil
+}
 
 // BasicAuthMiddleware provides HTTP Basic Authentication for web endpoints.
 func BasicAuthMiddleware(username, hashedPassword string, realm string) func(http.Handler) http.Handler {


### PR DESCRIPTION
## Summary

Addresses issues 2, 3, 4, 5, and 6 from ISSUES.md.

## Changes

### Issue 2: Barrage YAML settings not fully honored (High)
- Unified CLI and YAML execution paths into single flow in `cmd/barrage.go`
- Protocol selection now reads from `cfg.Protocol` (not CLI flag)
- Web server starts for both config-file and CLI modes
- Added `--web-username`/`--web-password` flags with environment variable fallback (`FLOWGRE_WEB_USERNAME`/`FLOWGRE_WEB_PASSWORD`)
- Non-loopback binding requires explicit credentials

### Issue 3: Zero template interval does not disable retransmission (Medium)
- Removed `<= 0` to 30 override in `barrage.StartCtx`
- Added negative interval validation (returns error)
- Fixed nil ticker channel dereference in worker select (used separate `tmplChan` variable)

### Issue 4: Release packaging binary name mismatch (High)
- Defined `VERSION` at job level and used consistently across build, musl, BINARY env vars, and SBOM
- Added binary verification step before nfpm packaging
- Fixed musl build ldflags quoting

### Issue 5: Hard-coded web credentials (High/Medium)
- Added `WebUsername`/`WebPassword` to `models.Config`
- Support CLI flags, YAML keys, and environment variables
- Random password generation using `crypto/rand` when no credentials provided
- Empty web-ip defaults to loopback (`127.0.0.1`)
- Credential resolution moved before worker startup (fail-fast)
- `GenerateRandomPassword` now returns error for entropy failures

### Issue 6: README inconsistencies (Low)
- Fixed `web-ip` default from `0.0.0.0` to `127.0.0.1` everywhere
- Removed embedded contributor instructions (build commands, CI docs, branching strategy, etc.)
- Added new credential flag documentation
- Updated web dashboard security guidance

## Testing

All 13 packages pass. Added 8 new test functions:
- `TestValidateProtocol` — protocol validation
- `TestValidateWebBinding` — web binding safety (7 sub-tests)
- `TestResolveCredentials` — credential resolution (CLI, env, default)
- `TestResolveProfile` — profile resolution
- `TestGenerateRandomPassword` — random password generation with error handling
- `TestEffectiveWebIP` — empty web-ip defaults to loopback
- `TestValidateWebBindingEmptyIP` — empty web-ip is safe
- `TestValidateTemplateInterval` — zero, positive, negative interval validation
- `TestBarrageCommandNegativeTemplateInterval` — end-to-end negative interval rejection

## Files changed

9 files changed, 471 insertions(+), 241 deletions(-)

`.github/workflows/release.yml`
`AGENTS.md`
`README.md`
`barrage/barrage.go`
`cmd/barrage.go`
`cmd/cmd_test.go`
`config/config.go`
`models/models.go`
`web/web.go`