### PR TITLE
Fix: IPFIX RFC 7011 conformance

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,24 +334,25 @@ The IPFIX field types used follow the [IANA IPFIX Information Model](https://www
 
 | IPFIX Field Type | Value | Description |
 |---|---|---|
-| inOctets | 1026 | Input bytes |
-| outOctets | 1028 | Output bytes |
-| inPackets | 1025 | Input packets |
-| outPackets | 1027 | Output packets |
+| octetDeltaCount | 1 | Input bytes |
+| postOctetDeltaCount | 23 | Output bytes |
+| packetDeltaCount | 2 | Input packets |
+| postPacketDeltaCount | 24 | Output packets |
 | sourceIPv4Address | 8 | Source IPv4 address |
 | destinationIPv4Address | 12 | Destination IPv4 address |
-| sourceIPv6Address | 25 | Source IPv6 address |
-| destinationIPv6Address | 26 | Destination IPv6 address |
-| sourceIPv6PrefixLength | 47 | Source IPv6 prefix length |
-| destinationIPv6PrefixLength | 48 | Destination IPv6 prefix length |
+| sourceIPv6Address | 27 | Source IPv6 address |
+| destinationIPv6Address | 28 | Destination IPv6 address |
+| sourceIPv6PrefixLength | 29 | Source IPv6 prefix length |
+| destinationIPv6PrefixLength | 30 | Destination IPv6 prefix length |
 | sourceTransportPort | 7 | Source port |
 | destinationTransportPort | 11 | Destination port |
 | protocolIdentifier | 4 | IP protocol number |
-| tcpFlags | 6 | TCP flags |
+| tcpControlBits | 6 | TCP flags |
 | flowStartMilliseconds | 152 | Flow start time |
 | flowEndMilliseconds | 153 | Flow end time |
-| flowDirection | 1024 | Flow direction |
-| ipClassOfService | 3 | IP ToS/CoS value |
+| flowDirection | 61 | Flow direction |
+| ipClassOfService | 5 | IP ToS/CoS value |
+| flowEndReason | 136 | Flow end reason |
 
 ## Record Mode
 

--- a/barrage/barrage.go
+++ b/barrage/barrage.go
@@ -111,8 +111,9 @@ func worker(cfg *workerConfig) {
 			log.Printf("%s [%2d] Exiting due to signal\n", label, cfg.id)
 			return
 		case <-tmplChan:
-			// Retransmit template every templateInterval seconds
-			bytes, err := utils.SendPacket(conn, &net.UDPAddr{IP: destIP, Port: cfg.port}, tBuf, false)
+			// Regenerate template with current sequence number and export time
+			tmplBuf := cfg.gen.GenerateTemplateWithSeq(cfg.sourceID, session)
+			bytes, err := utils.SendPacket(conn, &net.UDPAddr{IP: destIP, Port: cfg.port}, tmplBuf, false)
 			if err != nil {
 				log.Printf("%s [%2d] Issue sending template packet: %v", label, cfg.id, err)
 				return
@@ -175,6 +176,8 @@ func StartCtx(ctx context.Context, config *models.Config, gen FlowGenerator) *Ru
 	wg.Add(config.Workers)
 	for w := 1; w <= config.Workers; w++ {
 		sourceID := utils.RandomNum(sourceIDMin, sourceIDMax)
+		// Each worker gets its own generator with independent sequence counter
+		workerGen := gen.ForWorker()
 		go worker(&workerConfig{
 			id:               w,
 			ctx:              ctx,
@@ -187,7 +190,7 @@ func StartCtx(ctx context.Context, config *models.Config, gen FlowGenerator) *Ru
 			templateInterval: config.TemplateInterval,
 			wg:               wg,
 			statsChan:        sc.StatsChan,
-			gen:              gen,
+			gen:              workerGen,
 		})
 	}
 

--- a/barrage/generator.go
+++ b/barrage/generator.go
@@ -17,11 +17,17 @@ type FlowGenerator interface {
 	Label() string
 	// GenerateTemplate creates the initial template packet for a source ID.
 	GenerateTemplate(sourceID int, session *netflow.Session) []byte
+	// GenerateTemplateWithSeq creates a template packet with the current
+	// sequence number. Used for template retransmissions.
+	GenerateTemplateWithSeq(sourceID int, session *netflow.Session) []byte
 	// GenerateOptionsData creates an options data packet (IPFIX only).
 	// Returns nil if the protocol does not support options templates.
 	GenerateOptionsData(sourceID int, session *netflow.Session) []byte
 	// GenerateData creates a data packet with the given number of flows.
 	GenerateData(flowCount int, sourceID int, srcRange, dstRange string, session *netflow.Session) ([]byte, error)
+	// ForWorker returns a per-worker copy with its own sequence counter.
+	// Each worker must have an independent sequence per RFC 7011 §3.1.
+	ForWorker() FlowGenerator
 }
 
 // netflowGenerator implements FlowGenerator for NetFlow v9.
@@ -35,6 +41,11 @@ func (g netflowGenerator) GenerateTemplate(sourceID int, session *netflow.Sessio
 	tFlow := netflow.GenerateTemplateNetflow(sourceID, session, g.profile)
 	buf := tFlow.ToBytes()
 	return buf.Bytes()
+}
+
+func (g netflowGenerator) GenerateTemplateWithSeq(sourceID int, session *netflow.Session) []byte {
+	// NetFlow v9 doesn't have sequence numbers in the same way
+	return g.GenerateTemplate(sourceID, session)
 }
 
 func (g netflowGenerator) GenerateOptionsData(sourceID int, session *netflow.Session) []byte {
@@ -51,30 +62,51 @@ func (g netflowGenerator) GenerateData(flowCount int, sourceID int, srcRange, ds
 	return buf.Bytes(), nil
 }
 
+// ForWorker returns the same generator (NetFlow uses session-based sequencing).
+func (g netflowGenerator) ForWorker() FlowGenerator { return g }
+
 // ipfixGenerator implements FlowGenerator for IPFIX (RFC 7011).
-type ipfixGenerator struct{}
+type ipfixGenerator struct {
+	seq *ipfix.IPFIXSequence
+}
 
 func (g ipfixGenerator) Label() string { return "IPFIX Worker" }
 
 func (g ipfixGenerator) GenerateTemplate(sourceID int, session *netflow.Session) []byte {
-	tFlow := ipfix.GenerateTemplateIPFIX(sourceID, session)
-	buf := tFlow.ToBytes()
+	tFlow := ipfix.GenerateTemplateIPFIX(sourceID, g.seq)
+	buf, _ := tFlow.ToBytes()
+	return buf.Bytes()
+}
+
+func (g ipfixGenerator) GenerateTemplateWithSeq(sourceID int, session *netflow.Session) []byte {
+	// Regenerate template with current sequence number and export time
+	tFlow := ipfix.GenerateTemplateIPFIX(sourceID, g.seq)
+	buf, _ := tFlow.ToBytes()
 	return buf.Bytes()
 }
 
 func (g ipfixGenerator) GenerateOptionsData(sourceID int, session *netflow.Session) []byte {
-	oFlow := ipfix.GenerateOptionsDataIPFIX(sourceID, session)
-	buf := oFlow.ToBytes()
+	oFlow := ipfix.GenerateOptionsDataIPFIX(sourceID, g.seq)
+	buf, _ := oFlow.ToBytes()
 	return buf.Bytes()
 }
 
 func (g ipfixGenerator) GenerateData(flowCount int, sourceID int, srcRange, dstRange string, session *netflow.Session) ([]byte, error) {
-	flow, err := ipfix.GenerateDataIPFIX(flowCount, sourceID, srcRange, dstRange, 0, session)
+	flow, err := ipfix.GenerateDataIPFIX(flowCount, sourceID, srcRange, dstRange, 0, g.seq)
 	if err != nil {
 		return nil, fmt.Errorf("GenerateDataIPFIX failed: %w", err)
 	}
-	buf := flow.ToBytes()
+	buf, err := flow.ToBytes()
+	if err != nil {
+		return nil, fmt.Errorf("IPFIX ToBytes failed: %w", err)
+	}
 	return buf.Bytes(), nil
+}
+
+// ForWorker returns a new generator with its own IPFIXSequence.
+// Each worker must have an independent sequence per RFC 7011 §3.1.
+func (g ipfixGenerator) ForWorker() FlowGenerator {
+	return ipfixGenerator{seq: ipfix.NewIPFIXSequence()}
 }
 
 // NetFlow returns a FlowGenerator for NetFlow v9.
@@ -88,4 +120,6 @@ func NetFlow(profile ...netflow.FlowProfile) FlowGenerator {
 }
 
 // IPFIX returns a FlowGenerator for IPFIX (RFC 7011).
-func IPFIX() FlowGenerator { return ipfixGenerator{} }
+func IPFIX() FlowGenerator {
+	return ipfixGenerator{seq: ipfix.NewIPFIXSequence()}
+}

--- a/cmd/ipfix_single.go
+++ b/cmd/ipfix_single.go
@@ -11,7 +11,6 @@ import (
 	"os"
 
 	"github.com/dmabry/flowgre/ipfix"
-	"github.com/dmabry/flowgre/netflow"
 	"github.com/dmabry/flowgre/utils"
 )
 
@@ -64,11 +63,14 @@ func (c *IPFIXCommand) Execute() error {
 		return fmt.Errorf("failed to parse destination IP %s", *c.server)
 	}
 
-	session := netflow.NewSession()
+	seq := ipfix.NewIPFIXSequence()
 
 	// Generate and send Template Flow
-	tFlow := ipfix.GenerateTemplateIPFIX(sourceID, session)
-	tBuf := tFlow.ToBytes()
+	tFlow := ipfix.GenerateTemplateIPFIX(sourceID, seq)
+	tBuf, err := tFlow.ToBytes()
+	if err != nil {
+		return fmt.Errorf("IPFIX template ToBytes: %w", err)
+	}
 	_, err = utils.SendPacket(conn, &net.UDPAddr{IP: destIP, Port: *c.port}, tBuf.Bytes(), *c.hexDump)
 	if err != nil {
 		return fmt.Errorf("issue sending IPFIX template: %w", err)
@@ -76,11 +78,14 @@ func (c *IPFIXCommand) Execute() error {
 
 	// Generate and send Data Flows
 	for i := 1; i <= *c.count; i++ {
-		flow, err := ipfix.GenerateDataIPFIX(10, sourceID, *c.srcRange, *c.dstRange, 0, session)
+		flow, err := ipfix.GenerateDataIPFIX(10, sourceID, *c.srcRange, *c.dstRange, 0, seq)
 		if err != nil {
 			return fmt.Errorf("GenerateDataIPFIX failed: %w", err)
 		}
-		buf := flow.ToBytes()
+		buf, err := flow.ToBytes()
+		if err != nil {
+			return fmt.Errorf("IPFIX data ToBytes: %w", err)
+		}
 		_, err = utils.SendPacket(conn, &net.UDPAddr{IP: destIP, Port: *c.port}, buf.Bytes(), *c.hexDump)
 		if err != nil {
 			return fmt.Errorf("issue sending IPFIX data: %w", err)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -375,7 +375,16 @@ func mustTempDir(t *testing.T) string {
 func makeFakeHeader(version uint16, size int) []byte {
 	buf := make([]byte, size)
 	binary.BigEndian.PutUint16(buf[:2], version)
-	binary.BigEndian.PutUint32(buf[4:8], 1)
+	// IPFIX has 16-byte header; set Length field for IPFIX
+	if version == 10 && size >= 16 {
+		binary.BigEndian.PutUint16(buf[2:4], uint16(size))
+		binary.BigEndian.PutUint32(buf[4:8], 1)
+		binary.BigEndian.PutUint32(buf[8:12], 1)
+		binary.BigEndian.PutUint32(buf[12:16], 1)
+	} else {
+		// NetFlow v9 has 20-byte header
+		binary.BigEndian.PutUint32(buf[4:8], 1)
+	}
 	return buf
 }
 

--- a/ipfix/concurrency_padding_test.go
+++ b/ipfix/concurrency_padding_test.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/dmabry/flowgre/netflow"
 	"github.com/dmabry/flowgre/utils"
 )
 
@@ -17,7 +16,6 @@ import (
 
 func TestTemplateFlowSet_Padding_Alignment(t *testing.T) {
 	t.Parallel()
-	session := netflow.NewSession()
 
 	cases := []struct {
 		name    string
@@ -30,8 +28,7 @@ func TestTemplateFlowSet_Padding_Alignment(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			tfs := new(TemplateFlowSet).Generate(session, tc.profile)
-			// Total length should be aligned to 4-byte boundary per RFC 7011
+			tfs := new(TemplateFlowSet).Generate(nil, tc.profile)
 			if tfs.Length%4 != 0 {
 				t.Errorf("%s: TemplateFlowSet length %d should be 4-byte aligned",
 					tc.name, tfs.Length)
@@ -42,10 +39,8 @@ func TestTemplateFlowSet_Padding_Alignment(t *testing.T) {
 
 func TestOptionsTemplateFlowSet_Padding_Alignment(t *testing.T) {
 	t.Parallel()
-	session := netflow.NewSession()
-	otfs := new(OptionsTemplateFlowSet).Generate(session)
+	otfs := new(OptionsTemplateFlowSet).Generate(nil)
 
-	// Total length should be aligned to 4-byte boundary per RFC 7011
 	if otfs.Length%4 != 0 {
 		t.Errorf("OptionsTemplateFlowSet length %d should be 4-byte aligned", otfs.Length)
 	}
@@ -53,9 +48,8 @@ func TestOptionsTemplateFlowSet_Padding_Alignment(t *testing.T) {
 
 func TestOptionsDataFlowSet_Padding_Alignment(t *testing.T) {
 	t.Parallel()
-	ods := new(OptionsDataFlowSet).Generate(618, "flowgre", 12345)
+	ods := new(OptionsDataFlowSet).Generate(618)
 
-	// Total length should be aligned to 4-byte boundary per RFC 7011
 	if ods.Length%4 != 0 {
 		t.Errorf("OptionsDataFlowSet length %d should be 4-byte aligned", ods.Length)
 	}
@@ -63,7 +57,6 @@ func TestOptionsDataFlowSet_Padding_Alignment(t *testing.T) {
 
 func TestDataFlowSet_Padding_Alignment(t *testing.T) {
 	t.Parallel()
-	session := netflow.NewSession()
 
 	cases := []struct {
 		name    string
@@ -76,7 +69,8 @@ func TestDataFlowSet_Padding_Alignment(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			dfs, err := new(DataFlowSet).Generate(1, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session, tc.profile)
+			seq := NewIPFIXSequence()
+			dfs, err := new(DataFlowSet).Generate(1, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, nil, tc.profile)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -85,16 +79,14 @@ func TestDataFlowSet_Padding_Alignment(t *testing.T) {
 				t.Errorf("%s: DataFlowSet length %d should be 4-byte aligned",
 					tc.name, dfs.Length)
 			}
+			_ = seq
 		})
 	}
 }
 
 func TestPadding_VariesByProfile(t *testing.T) {
 	t.Parallel()
-	session := netflow.NewSession()
 
-	// Different profiles have different field counts and sizes,
-	// so padding requirements vary. Verify each aligns independently.
 	type result struct {
 		length  uint16
 		padding int
@@ -107,7 +99,7 @@ func TestPadding_VariesByProfile(t *testing.T) {
 		&ExtendedIPFIXProfile{},
 		&GenericIPFIXProfile{},
 	} {
-		tfs := new(TemplateFlowSet).Generate(session, profile)
+		tfs := new(TemplateFlowSet).Generate(nil, profile)
 		results[profile.Name()] = result{length: tfs.Length, padding: tfs.Padding}
 	}
 
@@ -124,9 +116,9 @@ func TestPadding_VariesByProfile(t *testing.T) {
 // Concurrent safety tests
 // ---------------------------------------------------------------------------
 
-func TestSession_NextSeq_Concurrent(t *testing.T) {
+func TestIPFIXSequence_Reserve_Concurrent(t *testing.T) {
 	t.Parallel()
-	s := netflow.NewSession()
+	s := NewIPFIXSequence()
 	const numGoroutines = 100
 	var wg sync.WaitGroup
 	seen := make(map[uint32]bool)
@@ -136,7 +128,7 @@ func TestSession_NextSeq_Concurrent(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			seq := s.NextSeq()
+			seq := s.Reserve(1)
 			mu.Lock()
 			if seen[seq] {
 				t.Errorf("duplicate sequence number: %d", seq)
@@ -155,7 +147,7 @@ func TestSession_NextSeq_Concurrent(t *testing.T) {
 
 func TestGenerateIPFIX_Concurrent_Safe(t *testing.T) {
 	t.Parallel()
-	session := netflow.NewSession()
+	seq := NewIPFIXSequence()
 	const numGoroutines = 50
 	var wg sync.WaitGroup
 	var mu sync.Mutex
@@ -166,14 +158,14 @@ func TestGenerateIPFIX_Concurrent_Safe(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			ipfix, err := GenerateIPFIX(1, 618, "10.0.0.0/8", "10.0.0.0/8", session)
+			ipfix, err := GenerateIPFIX(1, 618, "10.0.0.0/8", "10.0.0.0/8", seq)
 			if err != nil {
 				errCh <- err
 				return
 			}
 
 			mu.Lock()
-			sequences = append(sequences, ipfix.Header.FlowSequence)
+			sequences = append(sequences, ipfix.Header.SequenceNumber)
 			mu.Unlock()
 		}()
 	}
@@ -197,34 +189,23 @@ func TestGenerateIPFIX_Concurrent_Safe(t *testing.T) {
 
 func TestGenerateTemplateIPFIX_Concurrent_Safe(t *testing.T) {
 	t.Parallel()
-	session := netflow.NewSession()
+	seq := NewIPFIXSequence()
 	const numGoroutines = 50
 	var wg sync.WaitGroup
-	var mu sync.Mutex
-	sequences := make([]uint32, 0, numGoroutines)
 
 	for i := 0; i < numGoroutines; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			ipfix := GenerateTemplateIPFIX(618, session)
-
-			mu.Lock()
-			sequences = append(sequences, ipfix.Header.FlowSequence)
-			mu.Unlock()
+			ipfix := GenerateTemplateIPFIX(618, seq)
+			// Template-only messages always have sequence 0 (no data records sent yet)
+			if ipfix.Header.SequenceNumber != 0 {
+				t.Errorf("Template message should have sequence 0, got %d", ipfix.Header.SequenceNumber)
+			}
 		}()
 	}
 
 	wg.Wait()
-
-	// Verify all sequences are unique
-	seen := make(map[uint32]bool)
-	for _, seq := range sequences {
-		if seen[seq] {
-			t.Errorf("duplicate sequence number from concurrent template generation: %d", seq)
-		}
-		seen[seq] = true
-	}
 }
 
 // ---------------------------------------------------------------------------
@@ -243,7 +224,7 @@ func TestProfileFieldDataAlignment_Minimal(t *testing.T) {
 
 	// Verify field types match MinimalIPFIXFlow struct
 	expectedTypes := []uint16{
-		InOctets, InPackets,
+		OctetDeltaCount, PacketDeltaCount,
 		SourceIPv4Address, DestinationIPv4Address,
 		SourceTransportPort, DestinationTransportPort,
 		ProtocolIdentifier,
@@ -267,8 +248,8 @@ func TestProfileFieldDataAlignment_Extended(t *testing.T) {
 
 	// Verify field types match ExtendedIPFIXProfile struct
 	expectedTypes := []uint16{
-		InOctets, OutOctets,
-		InPackets, OutPackets,
+		OctetDeltaCount, PostOctetDeltaCount,
+		PacketDeltaCount, PostPacketDeltaCount,
 		SourceIPv4Address, DestinationIPv4Address,
 		SourceTransportPort, DestinationTransportPort,
 		ProtocolIdentifier,
@@ -297,8 +278,8 @@ func TestProfileFieldDataAlignment_Generic(t *testing.T) {
 	}
 
 	// Verify first and last fields match expectations
-	if fields[0].Type != InOctets {
-		t.Errorf("first field type: got %d, want %d", fields[0].Type, InOctets)
+	if fields[0].Type != OctetDeltaCount {
+		t.Errorf("first field type: got %d, want %d", fields[0].Type, OctetDeltaCount)
 	}
 	if fields[len(fields)-1].Type != FlowEndReason {
 		t.Errorf("last field type: got %d, want %d", fields[len(fields)-1].Type, FlowEndReason)
@@ -311,9 +292,8 @@ func TestProfileFieldDataAlignment_Generic(t *testing.T) {
 
 func TestDataFlowSet_Padding_ZeroFlowCount(t *testing.T) {
 	t.Parallel()
-	session := netflow.NewSession()
 
-	dfs, err := new(DataFlowSet).Generate(0, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session)
+	dfs, err := new(DataFlowSet).Generate(0, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -324,30 +304,24 @@ func TestDataFlowSet_Padding_ZeroFlowCount(t *testing.T) {
 	}
 }
 
-func TestOptionsDataFlowSet_Padding_ProcessName(t *testing.T) {
+func TestOptionsDataFlowSet_Padding(t *testing.T) {
 	t.Parallel()
-
-	// Test with various process name lengths to exercise padding calculations
-	testCases := []struct {
-		name string
-		len  int
-	}{
-		{"short", 5},
-		{"medium", 20},
-		{"long", 50},
+	ods := new(OptionsDataFlowSet).Generate(618)
+	if ods.Length%4 != 0 {
+		t.Errorf("OptionsDataFlowSet length %d not 4-byte aligned", ods.Length)
 	}
+}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			processName := make([]byte, tc.len)
-			for i := range processName {
-				processName[i] = byte('a' + i%26)
-			}
-			ods := new(OptionsDataFlowSet).Generate(618, string(processName), 12345)
-			if ods.Length%4 != 0 {
-				t.Errorf("OptionsDataFlowSet length %d not 4-byte aligned with %d-char process name",
-					ods.Length, tc.len)
-			}
-		})
+// ---------------------------------------------------------------------------
+// Set ID constants
+// ---------------------------------------------------------------------------
+
+func TestSetID_Constants(t *testing.T) {
+	t.Parallel()
+	if SetIDTemplate != 2 {
+		t.Errorf("SetIDTemplate should be 2, got %d", SetIDTemplate)
+	}
+	if SetIDOptionsTemplate != 3 {
+		t.Errorf("SetIDOptionsTemplate should be 3, got %d", SetIDOptionsTemplate)
 	}
 }

--- a/ipfix/ipfix.go
+++ b/ipfix/ipfix.go
@@ -403,6 +403,13 @@ func (f *IPFIX) estimatedSize() int {
 	return size
 }
 
+// mustWriteBinary writes data to a bytes.Buffer using binary.Write.
+// bytes.Buffer.Write never fails, so errors are silently ignored.
+// This helper satisfies gosec G104 (unhandled errors).
+func mustWriteBinary(buf *bytes.Buffer, data any) {
+	_ = binary.Write(buf, binary.BigEndian, data)
+}
+
 // ToBytes serializes the IPFIX structure to a byte buffer for wire transmission.
 // The Header.Length is set to the total encoded message size.
 // Returns an error if the message exceeds the 65535-byte IPFIX limit.
@@ -411,14 +418,14 @@ func (f *IPFIX) ToBytes() (bytes.Buffer, error) {
 
 	// Serialize all FlowSets
 	for _, tFlow := range f.TemplateFlowSets {
-		binary.Write(&setsBuf, binary.BigEndian, tFlow.FlowSetID)
-		binary.Write(&setsBuf, binary.BigEndian, tFlow.Length)
+		mustWriteBinary(&setsBuf, tFlow.FlowSetID)
+		mustWriteBinary(&setsBuf, tFlow.Length)
 		for _, template := range tFlow.Templates {
-			binary.Write(&setsBuf, binary.BigEndian, template.TemplateID)
-			binary.Write(&setsBuf, binary.BigEndian, template.FieldCount)
+			mustWriteBinary(&setsBuf, template.TemplateID)
+			mustWriteBinary(&setsBuf, template.FieldCount)
 			for _, field := range template.Fields {
-				binary.Write(&setsBuf, binary.BigEndian, field.Type)
-				binary.Write(&setsBuf, binary.BigEndian, field.Length)
+				mustWriteBinary(&setsBuf, field.Type)
+				mustWriteBinary(&setsBuf, field.Length)
 			}
 		}
 		if tFlow.Padding > 0 {
@@ -427,15 +434,15 @@ func (f *IPFIX) ToBytes() (bytes.Buffer, error) {
 	}
 
 	for _, oFlow := range f.OptionsTemplateFlowSets {
-		binary.Write(&setsBuf, binary.BigEndian, oFlow.FlowSetID)
-		binary.Write(&setsBuf, binary.BigEndian, oFlow.Length)
+		mustWriteBinary(&setsBuf, oFlow.FlowSetID)
+		mustWriteBinary(&setsBuf, oFlow.Length)
 		t := oFlow.Template
-		binary.Write(&setsBuf, binary.BigEndian, t.TemplateID)
-		binary.Write(&setsBuf, binary.BigEndian, t.FieldCount)
-		binary.Write(&setsBuf, binary.BigEndian, t.ScopeFieldCount)
+		mustWriteBinary(&setsBuf, t.TemplateID)
+		mustWriteBinary(&setsBuf, t.FieldCount)
+		mustWriteBinary(&setsBuf, t.ScopeFieldCount)
 		for _, field := range t.Fields {
-			binary.Write(&setsBuf, binary.BigEndian, field.Type)
-			binary.Write(&setsBuf, binary.BigEndian, field.Length)
+			mustWriteBinary(&setsBuf, field.Type)
+			mustWriteBinary(&setsBuf, field.Length)
 		}
 		if oFlow.Padding > 0 {
 			setsBuf.Write(bytes.Repeat([]byte{0}, oFlow.Padding))
@@ -443,10 +450,10 @@ func (f *IPFIX) ToBytes() (bytes.Buffer, error) {
 	}
 
 	for _, dFlow := range f.DataFlowSets {
-		binary.Write(&setsBuf, binary.BigEndian, dFlow.FlowSetID)
-		binary.Write(&setsBuf, binary.BigEndian, dFlow.Length)
+		mustWriteBinary(&setsBuf, dFlow.FlowSetID)
+		mustWriteBinary(&setsBuf, dFlow.Length)
 		for _, item := range dFlow.Items {
-			binary.Write(&setsBuf, binary.BigEndian, item)
+			mustWriteBinary(&setsBuf, item)
 		}
 		if dFlow.Padding > 0 {
 			setsBuf.Write(bytes.Repeat([]byte{0}, dFlow.Padding))
@@ -454,10 +461,10 @@ func (f *IPFIX) ToBytes() (bytes.Buffer, error) {
 	}
 
 	for _, oData := range f.OptionsDataFlowSets {
-		binary.Write(&setsBuf, binary.BigEndian, oData.FlowSetID)
-		binary.Write(&setsBuf, binary.BigEndian, oData.Length)
+		mustWriteBinary(&setsBuf, oData.FlowSetID)
+		mustWriteBinary(&setsBuf, oData.Length)
 		for _, rec := range oData.Records {
-			binary.Write(&setsBuf, binary.BigEndian, rec.ObservationDomainId)
+			mustWriteBinary(&setsBuf, rec.ObservationDomainId)
 		}
 		if oData.Padding > 0 {
 			setsBuf.Write(bytes.Repeat([]byte{0}, oData.Padding))
@@ -479,11 +486,11 @@ func (f *IPFIX) ToBytes() (bytes.Buffer, error) {
 	// Write header with correct Length
 	h := f.Header
 	h.Length = uint16(totalLength)
-	binary.Write(&result, binary.BigEndian, h.Version)
-	binary.Write(&result, binary.BigEndian, h.Length)
-	binary.Write(&result, binary.BigEndian, h.ExportTime)
-	binary.Write(&result, binary.BigEndian, h.SequenceNumber)
-	binary.Write(&result, binary.BigEndian, h.ObservationDomainId)
+	mustWriteBinary(&result, h.Version)
+	mustWriteBinary(&result, h.Length)
+	mustWriteBinary(&result, h.ExportTime)
+	mustWriteBinary(&result, h.SequenceNumber)
+	mustWriteBinary(&result, h.ObservationDomainId)
 
 	// Write sets
 	result.Write(setsBytes)

--- a/ipfix/ipfix.go
+++ b/ipfix/ipfix.go
@@ -11,9 +11,8 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"log"
 	"net"
-	"os"
+	"sync/atomic"
 	"time"
 
 	"github.com/dmabry/flowgre/netflow"
@@ -23,58 +22,52 @@ import (
 // IPFIX version number per RFC 7011.
 const Version = 10
 
-// IANA IPFIX field type constants (RFC 7011 / Information Model)
+// RFC 7011 Section 3.3.2: Set ID constants.
 const (
+	SetIDTemplate        = 2
+	SetIDOptionsTemplate = 3
+)
+
+// IANA IPFIX Information Element identifiers (RFC 7011 / IANA registry).
+const (
+	OctetDeltaCount             = 1
+	PacketDeltaCount            = 2
+	IPClassOfService            = 5
 	ProtocolIdentifier          = 4
 	SourceTransportPort         = 7
 	SourceIPv4Address           = 8
 	DestinationTransportPort    = 11
 	DestinationIPv4Address      = 12
-	SourceIPv6Address           = 25
-	DestinationIPv6Address      = 26
-	SourceIPv6PrefixLength      = 47
-	DestinationIPv6PrefixLength = 48
-	FlowDirection               = 1024
-	InPackets                   = 1025
-	InOctets                    = 1026
-	OutPackets                  = 1027
-	OutOctets                   = 1028
-	IPClassOfService            = 3
+	PostOctetDeltaCount         = 23
+	PostPacketDeltaCount        = 24
+	SourceIPv6Address           = 27
+	DestinationIPv6Address      = 28
+	SourceIPv6PrefixLength      = 29
+	DestinationIPv6PrefixLength = 30
+	FlowDirection               = 61
 	TCPFlags                    = 6
 	FlowStartMilliseconds       = 152
 	FlowEndMilliseconds         = 153
-	FlowEndReason               = 157
-	// Options Template fields
-	ObservationDomainId = 31
-	ProcessName         = 279
-	ProcessId           = 278
+	FlowEndReason               = 136
+	ObservationDomainId         = 149
 )
 
-// Header is the IPFIX export set header, structurally identical to NetFlow v9
-// but with version=10.
+// Header is the RFC 7011 Section 3.1 IPFIX Message Header (16 bytes).
 type Header struct {
-	Version      uint16
-	FlowCount    uint16
-	SysUptime    uint32
-	UnixSec      uint32
-	FlowSequence uint32
-	SourceID     uint32
+	Version             uint16 // 10 for IPFIX
+	Length              uint16 // total message length including this header
+	ExportTime          uint32 // Unix epoch seconds
+	SequenceNumber      uint32 // cumulative count of Data Records
+	ObservationDomainId uint32 // observation domain identifier
 }
 
-// Generate creates an IPFIX Header with version 10.
-func (h *Header) Generate(flowSetCount int, sourceID int, session *netflow.Session) Header {
-	now := time.Now().UnixNano()
-	secs := now / int64(time.Second)
-	startTime := session.StartTime()
-	sysUptime := uint32((now-startTime)/int64(time.Millisecond)) + 1000
-
+// Generate creates an RFC 7011 IPFIX Header.
+func (h *Header) Generate(sourceID int, sequenceNum uint32) Header {
 	return Header{
-		Version:      Version,
-		SysUptime:    sysUptime,
-		UnixSec:      uint32(secs),
-		FlowCount:    uint16(flowSetCount),
-		FlowSequence: session.NextSeq(),
-		SourceID:     uint32(sourceID),
+		Version:             Version,
+		ExportTime:          uint32(time.Now().Unix()),
+		SequenceNumber:      sequenceNum,
+		ObservationDomainId: uint32(sourceID),
 	}
 }
 
@@ -92,7 +85,7 @@ type Template struct {
 }
 
 // TemplateFlowSet wraps a collection of Template records.
-// Per IPFIX spec, FlowSetID is always 0 for template FlowSets.
+// Per RFC 7011, FlowSetID is 2 for Template Sets.
 type TemplateFlowSet struct {
 	FlowSetID uint16
 	Length    uint16
@@ -102,8 +95,8 @@ type TemplateFlowSet struct {
 
 // Generate creates a TemplateFlowSet with IPFIX field types.
 // If profile is nil, defaults to GenericIPFIXProfile for backward compatibility.
-func (t *TemplateFlowSet) Generate(session *netflow.Session, profile ...IPFIXFlowProfile) TemplateFlowSet {
-	p := IPFIXFlowProfile(&GenericIPFIXProfile{}) // default
+func (t *TemplateFlowSet) Generate(_ *netflow.Session, profile ...IPFIXFlowProfile) TemplateFlowSet {
+	p := IPFIXFlowProfile(&GenericIPFIXProfile{})
 	if len(profile) > 0 && profile[0] != nil {
 		p = profile[0]
 	}
@@ -116,7 +109,8 @@ func (t *TemplateFlowSet) Generate(session *netflow.Session, profile ...IPFIXFlo
 		Fields:     fields,
 	}
 
-	rawSize := 4 + 4 + len(fields)*4 // FlowSetID+Length + TemplateID+FieldCount + fields
+	// FlowSetID(2) + Length(2) + TemplateID(2) + FieldCount(2) + fields*N*4
+	rawSize := 4 + 4 + len(fields)*4
 	padding := 0
 	remainder := rawSize % 4
 	if remainder > 0 {
@@ -125,25 +119,23 @@ func (t *TemplateFlowSet) Generate(session *netflow.Session, profile ...IPFIXFlo
 	}
 
 	return TemplateFlowSet{
-		FlowSetID: 0,
+		FlowSetID: SetIDTemplate,
 		Length:    uint16(rawSize),
 		Templates: []Template{template},
 		Padding:   padding,
 	}
 }
 
-// OptionsTemplate describes an IPFIX Options Template record.
-// Per RFC 7011, Options Templates have two field lists: Scope Fields and Data Fields.
+// OptionsTemplate describes an RFC 7011 Section 3.4.2.2 Options Template record.
 type OptionsTemplate struct {
 	TemplateID      uint16
+	FieldCount      uint16 // total field count (scope + non-scope)
 	ScopeFieldCount uint16
-	ScopeFields     []Field
-	DataFieldCount  uint16
-	DataFields      []Field
+	Fields          []Field // first ScopeFieldCount are scope, remainder are non-scope
 }
 
 // OptionsTemplateFlowSet wraps an Options Template record.
-// Per IPFIX spec, FlowSetID is always 0 for template FlowSets (including options).
+// Per RFC 7011, FlowSetID is 3 for Options Template Sets.
 type OptionsTemplateFlowSet struct {
 	FlowSetID uint16
 	Length    uint16
@@ -151,19 +143,19 @@ type OptionsTemplateFlowSet struct {
 	Padding   int
 }
 
-// Generate creates an OptionsTemplateFlowSet with process metadata fields.
-func (o *OptionsTemplateFlowSet) Generate(session *netflow.Session) OptionsTemplateFlowSet {
+// Generate creates an OptionsTemplateFlowSet.
+func (o *OptionsTemplateFlowSet) Generate(_ *netflow.Session) OptionsTemplateFlowSet {
 	scopeFields := []Field{
 		{Type: ObservationDomainId, Length: 4},
 	}
-	dataFields := []Field{
-		{Type: ProcessName, Length: 0}, // variable-length, set at serialization
-		{Type: ProcessId, Length: 4},
-	}
 
-	// Calculate raw size: FlowSetID(2) + Length(2) + TemplateID(2) + ScopeFieldCount(2)
-	// + ScopeFields[Scope(2)+Len(2)] + DataFieldCount(2) + DataFields[(2+2)*N]
-	rawSize := 4 + 4 + len(scopeFields)*4 + 2 + len(dataFields)*4
+	// All fields (scope + non-scope)
+	allFields := append([]Field{}, scopeFields...)
+
+	// Calculate raw size:
+	// FlowSetID(2) + Length(2) + TemplateID(2) + FieldCount(2) + ScopeFieldCount(2)
+	// + allFields*N*4
+	rawSize := 4 + 6 + len(allFields)*4
 	padding := 0
 	remainder := rawSize % 4
 	if remainder > 0 {
@@ -172,14 +164,13 @@ func (o *OptionsTemplateFlowSet) Generate(session *netflow.Session) OptionsTempl
 	}
 
 	return OptionsTemplateFlowSet{
-		FlowSetID: 0,
+		FlowSetID: SetIDOptionsTemplate,
 		Length:    uint16(rawSize),
 		Template: OptionsTemplate{
 			TemplateID:      257,
+			FieldCount:      uint16(len(allFields)),
 			ScopeFieldCount: uint16(len(scopeFields)),
-			ScopeFields:     scopeFields,
-			DataFieldCount:  uint16(len(dataFields)),
-			DataFields:      dataFields,
+			Fields:          allFields,
 		},
 		Padding: padding,
 	}
@@ -188,8 +179,6 @@ func (o *OptionsTemplateFlowSet) Generate(session *netflow.Session) OptionsTempl
 // OptionsDataRecord holds a single Options Data record.
 type OptionsDataRecord struct {
 	ObservationDomainId uint32
-	ProcessName         string
-	ProcessId           uint32
 }
 
 // OptionsDataFlowSet holds Options Data records.
@@ -200,21 +189,16 @@ type OptionsDataFlowSet struct {
 	Padding   int
 }
 
-// Generate creates an OptionsDataFlowSet with process metadata.
-func (o *OptionsDataFlowSet) Generate(sourceID int, processName string, pid uint32) OptionsDataFlowSet {
+// Generate creates an OptionsDataFlowSet with observation domain metadata.
+func (o *OptionsDataFlowSet) Generate(sourceID int) OptionsDataFlowSet {
 	records := []OptionsDataRecord{
 		{
 			ObservationDomainId: uint32(sourceID),
-			ProcessName:         processName,
-			ProcessId:           pid,
 		},
 	}
 
-	// Calculate length: FlowSetID(2) + Length(2) + ScopeValues + DataValues + padding
-	// Scope: ObservationDomainId(4)
-	// Data: ProcessNameLen(2) + ProcessName(N) + ProcessId(4)
-	recordSize := 4 + 2 + len(processName) + 4
-	length := 4 + recordSize
+	// FlowSetID(2) + Length(2) + ObservationDomainId(4) = 8
+	length := 8
 	padding := 0
 	remainder := length % 4
 	if remainder > 0 {
@@ -223,7 +207,7 @@ func (o *OptionsDataFlowSet) Generate(sourceID int, processName string, pid uint
 	}
 
 	return OptionsDataFlowSet{
-		FlowSetID: 257, // Must match Options TemplateID
+		FlowSetID: 257,
 		Length:    uint16(length),
 		Records:   records,
 		Padding:   padding,
@@ -231,38 +215,36 @@ func (o *OptionsDataFlowSet) Generate(sourceID int, processName string, pid uint
 }
 
 // GenericFlow represents an IPFIX flow record with IANA field types.
-// Field order must match GetTemplateFields() exactly — binary.Write
-// serializes in struct field order, and the template defines the wire format.
+// Field order must match GetTemplateFields() exactly.
 type GenericFlow struct {
-	InOctets           uint32
-	OutOctets          uint32
-	InPackets          uint32
-	OutPackets         uint32
-	SourceIPv4Addr     uint32
-	DestIPv4Addr       uint32
-	SourceIPv6Addr     [16]byte
-	DestIPv6Addr       [16]byte
-	SourceIPv6Prefix   uint8
-	DestIPv6Prefix     uint8
-	SourcePort         uint16
-	DestPort           uint16
-	ProtocolIdentifier uint8
-	TCPFlags           uint8
-	FlowStartMillis    uint32
-	FlowEndMillis      uint32
-	FlowDirection      uint8
-	IPClassOfService   uint8
-	FlowEndReason      uint8
+	OctetDeltaCount      uint32
+	PostOctetDeltaCount  uint32
+	PacketDeltaCount     uint32
+	PostPacketDeltaCount uint32
+	SourceIPv4Addr       uint32
+	DestIPv4Addr         uint32
+	SourceIPv6Addr       [16]byte
+	DestIPv6Addr         [16]byte
+	SourceIPv6Prefix     uint8
+	DestIPv6Prefix       uint8
+	SourcePort           uint16
+	DestPort             uint16
+	ProtocolIdentifier   uint8
+	TCPFlags             uint8
+	FlowStartMillis      uint64
+	FlowEndMillis        uint64
+	FlowDirection        uint8
+	IPClassOfService     uint8
+	FlowEndReason        uint8
 }
 
 // GetTemplateFields returns the IPFIX field definitions for the template.
-// Field order must match GenericFlow struct field order exactly.
 func (gf *GenericFlow) GetTemplateFields() []Field {
 	return []Field{
-		{Type: InOctets, Length: 4},
-		{Type: OutOctets, Length: 4},
-		{Type: InPackets, Length: 4},
-		{Type: OutPackets, Length: 4},
+		{Type: OctetDeltaCount, Length: 4},
+		{Type: PostOctetDeltaCount, Length: 4},
+		{Type: PacketDeltaCount, Length: 4},
+		{Type: PostPacketDeltaCount, Length: 4},
 		{Type: SourceIPv4Address, Length: 4},
 		{Type: DestinationIPv4Address, Length: 4},
 		{Type: SourceIPv6Address, Length: 16},
@@ -273,8 +255,8 @@ func (gf *GenericFlow) GetTemplateFields() []Field {
 		{Type: DestinationTransportPort, Length: 2},
 		{Type: ProtocolIdentifier, Length: 1},
 		{Type: TCPFlags, Length: 1},
-		{Type: FlowStartMilliseconds, Length: 4},
-		{Type: FlowEndMilliseconds, Length: 4},
+		{Type: FlowStartMilliseconds, Length: 8},
+		{Type: FlowEndMilliseconds, Length: 8},
 		{Type: FlowDirection, Length: 1},
 		{Type: IPClassOfService, Length: 1},
 		{Type: FlowEndReason, Length: 1},
@@ -282,18 +264,15 @@ func (gf *GenericFlow) GetTemplateFields() []Field {
 }
 
 // Generate creates a GenericFlow with randomly generated data.
-// Populates both IPv4 and IPv6 fields based on the input IP version.
 func (gf *GenericFlow) Generate(srcIP net.IP, dstIP net.IP, flowSrcPort int, session *netflow.Session) GenericFlow {
-	now := time.Now().UnixNano()
-	startTime := session.StartTime()
-	uptimeMillis := uint32((now-startTime)/int64(time.Millisecond)) + 1000
+	now := time.Now()
+	epochMillis := uint64(now.UnixMilli())
 
-	gf.InOctets = utils.GenerateRand32(10000)
-	gf.OutOctets = utils.GenerateRand32(10000)
-	gf.InPackets = utils.GenerateRand32(10000)
-	gf.OutPackets = utils.GenerateRand32(10000)
+	gf.OctetDeltaCount = utils.GenerateRand32(10000)
+	gf.PostOctetDeltaCount = utils.GenerateRand32(10000)
+	gf.PacketDeltaCount = utils.GenerateRand32(10000)
+	gf.PostPacketDeltaCount = utils.GenerateRand32(10000)
 
-	// Populate IP addresses based on version
 	if srcIP.To4() != nil {
 		gf.SourceIPv4Addr = utils.IPToNum(srcIP)
 		gf.DestIPv4Addr = utils.IPToNum(dstIP)
@@ -306,17 +285,17 @@ func (gf *GenericFlow) Generate(srcIP net.IP, dstIP net.IP, flowSrcPort int, ses
 		gf.DestIPv4Addr = 0
 		copy(gf.SourceIPv6Addr[:], srcIP.To16())
 		copy(gf.DestIPv6Addr[:], dstIP.To16())
-		gf.SourceIPv6Prefix = 64 // Default /64
-		gf.DestIPv6Prefix = 64   // Default /64
+		gf.SourceIPv6Prefix = 64
+		gf.DestIPv6Prefix = 64
 	}
 
 	gf.SourcePort = utils.GenerateRand16(10000)
 	gf.TCPFlags = uint8(utils.RandomNum(0, 32))
-	gf.FlowStartMillis = uptimeMillis - 100
-	gf.FlowEndMillis = uptimeMillis - 10
+	gf.FlowStartMillis = epochMillis - 100
+	gf.FlowEndMillis = epochMillis - 10
 	gf.FlowDirection = 0
 	gf.IPClassOfService = 0
-	gf.FlowEndReason = uint8(utils.RandomNum(0, 4)) // 0=active, 1=idle, 2=other, 3=exporterReset, 4=exporterShutdown
+	gf.FlowEndReason = uint8(utils.RandomNum(0, 4))
 
 	gf.DestPort, gf.ProtocolIdentifier = utils.ResolvePortProtocol(flowSrcPort)
 
@@ -335,9 +314,8 @@ type DataFlowSet struct {
 }
 
 // Generate creates a DataFlowSet with random flow data.
-// If profile is nil, defaults to GenericIPFIXProfile for backward compatibility.
 func (d *DataFlowSet) Generate(flowCount int, srcRange string, dstRange string, flowSrcPort int, session *netflow.Session, profile ...IPFIXFlowProfile) (DataFlowSet, error) {
-	_ = profile // reserved for future profile-aware data generation
+	_ = profile
 
 	protoPorts := utils.ProtoPorts
 
@@ -368,8 +346,15 @@ func (d *DataFlowSet) Generate(flowCount int, srcRange string, dstRange string, 
 		length += padding
 	}
 
+	// Validate full-width length before converting to uint16.
+	// Without this check, length wraps and estimatedSize() sees a small value,
+	// allowing oversized packets to reserve sequence numbers before ToBytes() rejects them.
+	if length > 65535 {
+		return DataFlowSet{}, fmt.Errorf("DataFlowSet length %d exceeds maximum 65535 bytes", length)
+	}
+
 	return DataFlowSet{
-		FlowSetID: 256, // Must match TemplateID
+		FlowSetID: 256,
 		Length:    uint16(length),
 		Items:     items,
 		Padding:   padding,
@@ -385,188 +370,365 @@ type IPFIX struct {
 	OptionsDataFlowSets     []OptionsDataFlowSet
 }
 
+// dataRecordCount returns the total number of Data Records across all DataFlowSets
+// and OptionsDataFlowSets. Per RFC 7011, only Data Records contribute to the
+// Sequence Number.
+func (f *IPFIX) dataRecordCount() int {
+	count := 0
+	for _, dfs := range f.DataFlowSets {
+		count += len(dfs.Items)
+	}
+	for _, odfs := range f.OptionsDataFlowSets {
+		count += len(odfs.Records)
+	}
+	return count
+}
+
+// estimatedSize returns the estimated message size in bytes.
+// This is used to check for overflow before reserving sequence numbers.
+func (f *IPFIX) estimatedSize() int {
+	size := 16 // header
+	for _, tfs := range f.TemplateFlowSets {
+		size += int(tfs.Length)
+	}
+	for _, ots := range f.OptionsTemplateFlowSets {
+		size += int(ots.Length)
+	}
+	for _, dfs := range f.DataFlowSets {
+		size += int(dfs.Length)
+	}
+	for _, ods := range f.OptionsDataFlowSets {
+		size += int(ods.Length)
+	}
+	return size
+}
+
 // ToBytes serializes the IPFIX structure to a byte buffer for wire transmission.
-func (f *IPFIX) ToBytes() bytes.Buffer {
-	var buf bytes.Buffer
-	if err := binary.Write(&buf, binary.BigEndian, f.Header); err != nil {
-		log.Printf("[ERROR] Issue writing IPFIX header: %v", err)
-	}
+// The Header.Length is set to the total encoded message size.
+// Returns an error if the message exceeds the 65535-byte IPFIX limit.
+func (f *IPFIX) ToBytes() (bytes.Buffer, error) {
+	var setsBuf bytes.Buffer
 
+	// Serialize all FlowSets
 	for _, tFlow := range f.TemplateFlowSets {
-		if err := binary.Write(&buf, binary.BigEndian, tFlow.FlowSetID); err != nil {
-			log.Printf("[ERROR] Issue writing IPFIX Template FlowSetID: %v", err)
-		}
-		if err := binary.Write(&buf, binary.BigEndian, tFlow.Length); err != nil {
-			log.Printf("[ERROR] Issue writing IPFIX Template Length: %v", err)
-		}
+		binary.Write(&setsBuf, binary.BigEndian, tFlow.FlowSetID)
+		binary.Write(&setsBuf, binary.BigEndian, tFlow.Length)
 		for _, template := range tFlow.Templates {
-			if err := binary.Write(&buf, binary.BigEndian, template.TemplateID); err != nil {
-				log.Printf("[ERROR] Issue writing IPFIX Template ID: %v", err)
-			}
-			if err := binary.Write(&buf, binary.BigEndian, template.FieldCount); err != nil {
-				log.Printf("[ERROR] Issue writing IPFIX Template FieldCount: %v", err)
-			}
+			binary.Write(&setsBuf, binary.BigEndian, template.TemplateID)
+			binary.Write(&setsBuf, binary.BigEndian, template.FieldCount)
 			for _, field := range template.Fields {
-				if err := binary.Write(&buf, binary.BigEndian, field.Type); err != nil {
-					log.Printf("[ERROR] Issue writing IPFIX Field Type: %v", err)
-				}
-				if err := binary.Write(&buf, binary.BigEndian, field.Length); err != nil {
-					log.Printf("[ERROR] Issue writing IPFIX Field Length: %v", err)
-				}
+				binary.Write(&setsBuf, binary.BigEndian, field.Type)
+				binary.Write(&setsBuf, binary.BigEndian, field.Length)
 			}
 		}
-		// Padding to 32-bit boundary per IPFIX RFC 7011
 		if tFlow.Padding > 0 {
-			padBytes := bytes.Repeat([]byte{0}, tFlow.Padding)
-			if err := binary.Write(&buf, binary.BigEndian, padBytes); err != nil {
-				log.Printf("[ERROR] Issue writing IPFIX Template Padding: %v", err)
-			}
+			setsBuf.Write(bytes.Repeat([]byte{0}, tFlow.Padding))
 		}
 	}
 
-	// Serialize Options Template FlowSets
 	for _, oFlow := range f.OptionsTemplateFlowSets {
-		if err := binary.Write(&buf, binary.BigEndian, oFlow.FlowSetID); err != nil {
-			log.Printf("[ERROR] Issue writing IPFIX Options Template FlowSetID: %v", err)
-		}
-		if err := binary.Write(&buf, binary.BigEndian, oFlow.Length); err != nil {
-			log.Printf("[ERROR] Issue writing IPFIX Options Template Length: %v", err)
-		}
+		binary.Write(&setsBuf, binary.BigEndian, oFlow.FlowSetID)
+		binary.Write(&setsBuf, binary.BigEndian, oFlow.Length)
 		t := oFlow.Template
-		if err := binary.Write(&buf, binary.BigEndian, t.TemplateID); err != nil {
-			log.Printf("[ERROR] Issue writing IPFIX Options Template ID: %v", err)
+		binary.Write(&setsBuf, binary.BigEndian, t.TemplateID)
+		binary.Write(&setsBuf, binary.BigEndian, t.FieldCount)
+		binary.Write(&setsBuf, binary.BigEndian, t.ScopeFieldCount)
+		for _, field := range t.Fields {
+			binary.Write(&setsBuf, binary.BigEndian, field.Type)
+			binary.Write(&setsBuf, binary.BigEndian, field.Length)
 		}
-		if err := binary.Write(&buf, binary.BigEndian, t.ScopeFieldCount); err != nil {
-			log.Printf("[ERROR] Issue writing IPFIX Options ScopeFieldCount: %v", err)
-		}
-		for _, field := range t.ScopeFields {
-			if err := binary.Write(&buf, binary.BigEndian, field.Type); err != nil {
-				log.Printf("[ERROR] Issue writing IPFIX Options Scope Field: %v", err)
-			}
-			if err := binary.Write(&buf, binary.BigEndian, field.Length); err != nil {
-				log.Printf("[ERROR] Issue writing IPFIX Options Scope Field Length: %v", err)
-			}
-		}
-		if err := binary.Write(&buf, binary.BigEndian, t.DataFieldCount); err != nil {
-			log.Printf("[ERROR] Issue writing IPFIX Options DataFieldCount: %v", err)
-		}
-		for _, field := range t.DataFields {
-			if err := binary.Write(&buf, binary.BigEndian, field.Type); err != nil {
-				log.Printf("[ERROR] Issue writing IPFIX Options Data Field: %v", err)
-			}
-			if err := binary.Write(&buf, binary.BigEndian, field.Length); err != nil {
-				log.Printf("[ERROR] Issue writing IPFIX Options Data Field Length: %v", err)
-			}
-		}
-		// Padding to 32-bit boundary per IPFIX RFC 7011
 		if oFlow.Padding > 0 {
-			padBytes := bytes.Repeat([]byte{0}, oFlow.Padding)
-			if err := binary.Write(&buf, binary.BigEndian, padBytes); err != nil {
-				log.Printf("[ERROR] Issue writing IPFIX Options Template Padding: %v", err)
-			}
+			setsBuf.Write(bytes.Repeat([]byte{0}, oFlow.Padding))
 		}
 	}
 
 	for _, dFlow := range f.DataFlowSets {
-		if err := binary.Write(&buf, binary.BigEndian, dFlow.FlowSetID); err != nil {
-			log.Printf("[ERROR] Issue writing IPFIX Data FlowSetID: %v", err)
-		}
-		if err := binary.Write(&buf, binary.BigEndian, dFlow.Length); err != nil {
-			log.Printf("[ERROR] Issue writing IPFIX Data FlowSet Length: %v", err)
-		}
+		binary.Write(&setsBuf, binary.BigEndian, dFlow.FlowSetID)
+		binary.Write(&setsBuf, binary.BigEndian, dFlow.Length)
 		for _, item := range dFlow.Items {
-			if err := binary.Write(&buf, binary.BigEndian, item); err != nil {
-				log.Printf("[ERROR] Issue writing IPFIX Data FlowSet Field: %v", err)
-			}
+			binary.Write(&setsBuf, binary.BigEndian, item)
 		}
-		// Padding to 32-bit boundary per IPFIX RFC 7011
 		if dFlow.Padding > 0 {
-			padBytes := bytes.Repeat([]byte{0}, dFlow.Padding)
-			if err := binary.Write(&buf, binary.BigEndian, padBytes); err != nil {
-				log.Printf("[ERROR] Issue writing IPFIX Data Padding: %v", err)
-			}
+			setsBuf.Write(bytes.Repeat([]byte{0}, dFlow.Padding))
 		}
 	}
 
-	// Serialize Options Data FlowSets
 	for _, oData := range f.OptionsDataFlowSets {
-		if err := binary.Write(&buf, binary.BigEndian, oData.FlowSetID); err != nil {
-			log.Printf("[ERROR] Issue writing IPFIX Options Data FlowSetID: %v", err)
-		}
-		if err := binary.Write(&buf, binary.BigEndian, oData.Length); err != nil {
-			log.Printf("[ERROR] Issue writing IPFIX Options Data Length: %v", err)
-		}
+		binary.Write(&setsBuf, binary.BigEndian, oData.FlowSetID)
+		binary.Write(&setsBuf, binary.BigEndian, oData.Length)
 		for _, rec := range oData.Records {
-			// Scope values: ObservationDomainId
-			if err := binary.Write(&buf, binary.BigEndian, rec.ObservationDomainId); err != nil {
-				log.Printf("[ERROR] Issue writing IPFIX Options Scope Value: %v", err)
-			}
-			// Data values: ProcessName (variable-length with 2-byte length prefix) + ProcessId
-			if err := binary.Write(&buf, binary.BigEndian, uint16(len(rec.ProcessName))); err != nil {
-				log.Printf("[ERROR] Issue writing IPFIX Options ProcessName length: %v", err)
-			}
-			if err := binary.Write(&buf, binary.BigEndian, []byte(rec.ProcessName)); err != nil {
-				log.Printf("[ERROR] Issue writing IPFIX Options ProcessName: %v", err)
-			}
-			if err := binary.Write(&buf, binary.BigEndian, rec.ProcessId); err != nil {
-				log.Printf("[ERROR] Issue writing IPFIX Options ProcessId: %v", err)
-			}
+			binary.Write(&setsBuf, binary.BigEndian, rec.ObservationDomainId)
 		}
-		// Padding to 32-bit boundary per IPFIX RFC 7011
 		if oData.Padding > 0 {
-			padBytes := bytes.Repeat([]byte{0}, oData.Padding)
-			if err := binary.Write(&buf, binary.BigEndian, padBytes); err != nil {
-				log.Printf("[ERROR] Issue writing IPFIX Options Data Padding: %v", err)
-			}
+			setsBuf.Write(bytes.Repeat([]byte{0}, oData.Padding))
 		}
 	}
 
-	return buf
+	setsBytes := setsBuf.Bytes()
+	totalLength := 16 + len(setsBytes)
+
+	// Check for uint16 overflow
+	if totalLength > 65535 {
+		return bytes.Buffer{}, fmt.Errorf("IPFIX message size %d exceeds maximum 65535 bytes", totalLength)
+	}
+
+	// Build final buffer: header first, then sets
+	var result bytes.Buffer
+	result.Grow(totalLength)
+
+	// Write header with correct Length
+	h := f.Header
+	h.Length = uint16(totalLength)
+	binary.Write(&result, binary.BigEndian, h.Version)
+	binary.Write(&result, binary.BigEndian, h.Length)
+	binary.Write(&result, binary.BigEndian, h.ExportTime)
+	binary.Write(&result, binary.BigEndian, h.SequenceNumber)
+	binary.Write(&result, binary.BigEndian, h.ObservationDomainId)
+
+	// Write sets
+	result.Write(setsBytes)
+
+	return result, nil
 }
 
-// IsValidIPFIX checks whether the given payload has a valid IPFIX header (version 10).
+// fieldSpecifierSize returns the size of a field specifier at the given offset.
+// Standard specifiers are 4 bytes; enterprise specifiers are 8 bytes.
+// RFC 7011 §3.2: The Enterprise bit is the high bit of Element Length.
+func fieldSpecifierSize(payload []byte, offset int) int {
+	if offset+4 > len(payload) {
+		return 4 // assume standard if we can't read
+	}
+	elementLength := binary.BigEndian.Uint16(payload[offset : offset+2])
+	if elementLength&0x8000 != 0 {
+		return 8 // enterprise specifier has 4-byte PEN
+	}
+	return 4
+}
+
+// validateTemplateRecord validates a Template record starting at setOffset.
+// Returns the number of bytes consumed (excluding padding).
+func validateTemplateRecord(payload []byte, setOffset, remaining int) (int, error) {
+	if remaining < 4 {
+		return 0, fmt.Errorf("insufficient data for Template record header")
+	}
+	templateID := binary.BigEndian.Uint16(payload[setOffset : setOffset+2])
+	fieldCount := binary.BigEndian.Uint16(payload[setOffset+2 : setOffset+4])
+
+	if templateID < 256 {
+		return 0, fmt.Errorf("Template ID %d is below 256", templateID)
+	}
+
+	// RFC 7011 §8.1: A Template Record with Field Count of 0 is a
+	// Template Withdrawal. It contains only the Template ID and Field Count.
+	if fieldCount == 0 {
+		return 4, nil
+	}
+
+	consumed := 4
+	for i := uint16(0); i < fieldCount; i++ {
+		if consumed+4 > remaining {
+			return 0, fmt.Errorf("insufficient data for field specifier %d", i)
+		}
+		specSize := fieldSpecifierSize(payload, setOffset+consumed)
+		if consumed+specSize > remaining {
+			return 0, fmt.Errorf("enterprise field specifier %d exceeds remaining bytes", i)
+		}
+		consumed += specSize
+	}
+	return consumed, nil
+}
+
+// validateOptionsTemplateRecord validates an Options Template record.
+// Returns the number of bytes consumed (excluding padding).
+func validateOptionsTemplateRecord(payload []byte, setOffset, remaining int) (int, error) {
+	if remaining < 4 {
+		return 0, fmt.Errorf("insufficient data for Options Template record header")
+	}
+	templateID := binary.BigEndian.Uint16(payload[setOffset : setOffset+2])
+	fieldCount := binary.BigEndian.Uint16(payload[setOffset+2 : setOffset+4])
+
+	if templateID < 256 {
+		return 0, fmt.Errorf("Options Template ID %d is below 256", templateID)
+	}
+
+	// RFC 7011 §8.1: Options Template Withdrawal is a 4-byte record with
+	// Template ID and Field Count of zero (no Scope Field Count field).
+	if fieldCount == 0 {
+		return 4, nil
+	}
+
+	// Normal Options Template: requires Scope Field Count (§3.4.2.2).
+	if remaining < 6 {
+		return 0, fmt.Errorf("insufficient data for Scope Field Count")
+	}
+	scopeFieldCount := binary.BigEndian.Uint16(payload[setOffset+4 : setOffset+6])
+
+	// RFC 7011 §3.4.2.2: Scope Field Count must be at least 1.
+	if scopeFieldCount == 0 {
+		return 0, fmt.Errorf("Scope Field Count must be at least 1")
+	}
+	if scopeFieldCount > fieldCount {
+		return 0, fmt.Errorf("Scope Field Count %d > Field Count %d", scopeFieldCount, fieldCount)
+	}
+
+	consumed := 6
+	for i := uint16(0); i < fieldCount; i++ {
+		if consumed+4 > remaining {
+			return 0, fmt.Errorf("insufficient data for field specifier %d", i)
+		}
+		specSize := fieldSpecifierSize(payload, setOffset+consumed)
+		if consumed+specSize > remaining {
+			return 0, fmt.Errorf("enterprise field specifier %d exceeds remaining bytes", i)
+		}
+		consumed += specSize
+	}
+	return consumed, nil
+}
+
+// IsValidIPFIX validates the given payload against RFC 7011.
 func IsValidIPFIX(payload []byte) (bool, error) {
-	header := Header{}
-	reader := bytes.NewReader(payload)
-	if err := binary.Read(reader, binary.BigEndian, &header); err != nil {
-		return false, err
+	if len(payload) < 16 {
+		return false, fmt.Errorf("payload too short for IPFIX header: %d bytes", len(payload))
 	}
-	if header.Version != Version {
-		return false, fmt.Errorf("header version is %d, expected IPFIX version %d", header.Version, Version)
+
+	version := binary.BigEndian.Uint16(payload[0:2])
+	if version != Version {
+		return false, fmt.Errorf("version %d is not IPFIX (expected %d)", version, Version)
 	}
+
+	messageLength := binary.BigEndian.Uint16(payload[2:4])
+	if int(messageLength) < 16 {
+		return false, fmt.Errorf("declared message length %d is less than minimum header size", messageLength)
+	}
+	if int(messageLength) != len(payload) {
+		return false, fmt.Errorf("declared message length %d does not match payload length %d", messageLength, len(payload))
+	}
+
+	offset := 16
+	limit := int(messageLength)
+	setCount := 0
+
+	for offset < limit {
+		if offset+4 > limit {
+			return false, fmt.Errorf("insufficient data for FlowSet header at offset %d", offset)
+		}
+
+		setID := binary.BigEndian.Uint16(payload[offset : offset+2])
+		setLength := binary.BigEndian.Uint16(payload[offset+2 : offset+4])
+
+		if setID == 0 || setID == 1 {
+			return false, fmt.Errorf("reserved Set ID %d at offset %d", setID, offset)
+		}
+
+		if setID >= 4 && setID <= 255 {
+			return false, fmt.Errorf("unassigned Set ID %d at offset %d", setID, offset)
+		}
+
+		if int(setLength) < 4 {
+			return false, fmt.Errorf("FlowSet length %d is less than minimum 4 at offset %d", setLength, offset)
+		}
+
+		setEnd := offset + int(setLength)
+		if setEnd > limit {
+			return false, fmt.Errorf("FlowSet at offset %d extends beyond message boundary", offset)
+		}
+
+		// Validate set contents based on type
+		remaining := int(setLength) - 4 // subtract FlowSet header
+		setOffset := offset + 4
+
+		switch setID {
+		case SetIDTemplate:
+			// Template Set: one or more Template records
+			recordsParsed := 0
+			for remaining >= 4 {
+				consumed, err := validateTemplateRecord(payload, setOffset, remaining)
+				if err != nil {
+					return false, fmt.Errorf("Template Set at offset %d: %w", offset, err)
+				}
+				setOffset += consumed
+				remaining -= consumed
+				recordsParsed++
+			}
+			if recordsParsed == 0 {
+				return false, fmt.Errorf("Template Set at offset %d contains no records", offset)
+			}
+		case SetIDOptionsTemplate:
+			// Options Template Set: one or more Options Template records.
+			// Minimum is 4 bytes (withdrawal: TemplateID + FieldCount).
+			recordsParsed := 0
+			for remaining >= 4 {
+				consumed, err := validateOptionsTemplateRecord(payload, setOffset, remaining)
+				if err != nil {
+					return false, fmt.Errorf("Options Template Set at offset %d: %w", offset, err)
+				}
+				setOffset += consumed
+				remaining -= consumed
+				recordsParsed++
+			}
+			if recordsParsed == 0 {
+				return false, fmt.Errorf("Options Template Set at offset %d contains no records", offset)
+			}
+		default:
+			// Data Set (ID >= 256): records are opaque, just check length
+		}
+
+		setCount++
+		offset = setEnd
+	}
+
+	// RFC 7011 permits zero or more Sets. A 16-byte header-only message is valid.
+
 	return true, nil
 }
 
-// UpdateTimeStamp updates the UnixSec timestamp in an IPFIX packet header to the current time.
+// UpdateTimeStamp updates the ExportTime field in an IPFIX packet header to the current time.
 func UpdateTimeStamp(payload []byte) ([]byte, error) {
-	header := Header{}
-	reader := bytes.NewReader(payload)
-	if err := binary.Read(reader, binary.BigEndian, &header); err != nil {
-		return nil, err
-	}
-	remainder := make([]byte, len(payload)-20)
-	if err := binary.Read(reader, binary.BigEndian, &remainder); err != nil {
-		return nil, err
+	if len(payload) < 16 {
+		return nil, fmt.Errorf("payload too short for IPFIX header: %d bytes", len(payload))
 	}
 
-	now := time.Now().UnixNano()
-	header.UnixSec = uint32(now / int64(time.Second))
+	result := make([]byte, len(payload))
+	copy(result, payload)
 
-	var buf bytes.Buffer
-	if err := binary.Write(&buf, binary.BigEndian, header); err != nil {
-		return nil, err
-	}
-	if err := binary.Write(&buf, binary.BigEndian, remainder); err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), nil
+	binary.BigEndian.PutUint32(result[4:8], uint32(time.Now().Unix()))
+
+	return result, nil
 }
 
-// GenerateTemplateIPFIX creates an IPFIX packet containing both data and options templates.
-func GenerateTemplateIPFIX(sourceID int, session *netflow.Session) IPFIX {
-	templateFlow := new(TemplateFlowSet).Generate(session)
-	optionsTemplate := new(OptionsTemplateFlowSet).Generate(session)
-	header := new(Header).Generate(1, sourceID, session)
+// IPFIXSequence tracks the RFC 7011 Data Record sequence number.
+// The sequence number counts Data Records exported before the current message.
+// Template and Options Template Records do not increment it.
+type IPFIXSequence struct {
+	counter atomic.Uint32
+}
+
+// NewIPFIXSequence creates a new sequence tracker.
+func NewIPFIXSequence() *IPFIXSequence {
+	return &IPFIXSequence{}
+}
+
+// Reserve returns the current sequence number and atomically advances
+// the counter by recordCount. The returned value is the sequence number
+// for the message containing recordCount Data Records.
+func (s *IPFIXSequence) Reserve(recordCount int) uint32 {
+	return s.counter.Add(uint32(recordCount)) - uint32(recordCount)
+}
+
+// Current returns the current sequence number without advancing.
+func (s *IPFIXSequence) Current() uint32 {
+	return s.counter.Load()
+}
+
+// GenerateTemplateIPFIX creates an IPFIX packet containing template and options template FlowSets.
+// The sequence number reflects the current count of Data Records sent.
+func GenerateTemplateIPFIX(sourceID int, seq *IPFIXSequence) IPFIX {
+	templateFlow := new(TemplateFlowSet).Generate(nil)
+	optionsTemplate := new(OptionsTemplateFlowSet).Generate(nil)
+
+	// Template messages carry the current Data Record count, don't advance it
+	header := new(Header).Generate(sourceID, seq.Current())
+
 	return IPFIX{
 		Header:                  header,
 		TemplateFlowSets:        []TemplateFlowSet{templateFlow},
@@ -577,14 +739,12 @@ func GenerateTemplateIPFIX(sourceID int, session *netflow.Session) IPFIX {
 }
 
 // GenerateOptionsDataIPFIX creates an IPFIX packet containing Options Data records.
-// This exports process metadata (process name and PID) to the collector.
-func GenerateOptionsDataIPFIX(sourceID int, session *netflow.Session) IPFIX {
-	// Use the actual process name and PID
-	processName := "flowgre-generator"
-	pid := uint32(os.Getpid())
+func GenerateOptionsDataIPFIX(sourceID int, seq *IPFIXSequence) IPFIX {
+	optionsData := new(OptionsDataFlowSet).Generate(sourceID)
 
-	optionsData := new(OptionsDataFlowSet).Generate(sourceID, processName, pid)
-	header := new(Header).Generate(1, sourceID, session)
+	// Options Data Records are Data Records; reserve sequence for 1 record
+	header := new(Header).Generate(sourceID, seq.Reserve(1))
+
 	return IPFIX{
 		Header:              header,
 		OptionsDataFlowSets: []OptionsDataFlowSet{optionsData},
@@ -592,47 +752,60 @@ func GenerateOptionsDataIPFIX(sourceID int, session *netflow.Session) IPFIX {
 }
 
 // GenerateDataIPFIX creates an IPFIX packet containing only data FlowSets.
-func GenerateDataIPFIX(flowCount int, sourceID int, srcRange string, dstRange string, flowSrcPort int, session *netflow.Session) (IPFIX, error) {
+func GenerateDataIPFIX(flowCount int, sourceID int, srcRange string, dstRange string, flowSrcPort int, seq *IPFIXSequence) (IPFIX, error) {
+	session := netflow.NewSession()
 	dataFlow, err := new(DataFlowSet).Generate(flowCount, srcRange, dstRange, flowSrcPort, session)
 	if err != nil {
 		return IPFIX{}, fmt.Errorf("generate data flow set: %w", err)
 	}
-	header := new(Header).Generate(1, sourceID, session)
-	return IPFIX{
-		Header:       header,
+
+	// Build the packet without header to check size first
+	flow := IPFIX{
 		DataFlowSets: []DataFlowSet{dataFlow},
-	}, nil
+	}
+	if flow.estimatedSize() > 65535 {
+		return IPFIX{}, fmt.Errorf("IPFIX message size %d exceeds maximum 65535 bytes", flow.estimatedSize())
+	}
+
+	// Size is OK; now reserve sequence range
+	flow.Header = new(Header).Generate(sourceID, seq.Reserve(flowCount))
+
+	return flow, nil
 }
 
 // GenerateIPFIX creates an IPFIX packet containing both template and data FlowSets.
-func GenerateIPFIX(flowCount int, sourceID int, srcRange string, dstRange string, session *netflow.Session) (IPFIX, error) {
-	templateFlow := new(TemplateFlowSet).Generate(session)
+func GenerateIPFIX(flowCount int, sourceID int, srcRange string, dstRange string, seq *IPFIXSequence) (IPFIX, error) {
+	templateFlow := new(TemplateFlowSet).Generate(nil)
+	session := netflow.NewSession()
 	dataFlow, err := new(DataFlowSet).Generate(flowCount, srcRange, dstRange, utils.HTTPSPort, session)
 	if err != nil {
 		return IPFIX{}, fmt.Errorf("generate data flow set: %w", err)
 	}
-	header := new(Header).Generate(flowCount+1, sourceID, session)
-	return IPFIX{
-		Header:           header,
+
+	// Build the packet without header to check size first
+	flow := IPFIX{
 		TemplateFlowSets: []TemplateFlowSet{templateFlow},
 		DataFlowSets:     []DataFlowSet{dataFlow},
-	}, nil
+	}
+	if flow.estimatedSize() > 65535 {
+		return IPFIX{}, fmt.Errorf("IPFIX message size %d exceeds maximum 65535 bytes", flow.estimatedSize())
+	}
+
+	// Size is OK; now reserve sequence range
+	flow.Header = new(Header).Generate(sourceID, seq.Reserve(flowCount))
+
+	return flow, nil
 }
 
-// size returns the size of the Header in bytes.
+// size returns the size of the Header in bytes (always 16 per RFC 7011).
 func (h *Header) size() int {
-	return binary.Size(h.Version) +
-		binary.Size(h.FlowCount) +
-		binary.Size(h.SysUptime) +
-		binary.Size(h.UnixSec) +
-		binary.Size(h.FlowSequence) +
-		binary.Size(h.SourceID)
+	return 16
 }
 
 // String returns a human-readable representation of the Header.
 func (h *Header) String() string {
-	return fmt.Sprintf("Version: %d Count: %d SysUptime: %d UnixSec: %d FlowSequence: %d SourceID: %d",
-		h.Version, h.FlowCount, h.SysUptime, h.UnixSec, h.FlowSequence, h.SourceID)
+	return fmt.Sprintf("Version: %d Length: %d ExportTime: %d SequenceNumber: %d ObservationDomainId: %d",
+		h.Version, h.Length, h.ExportTime, h.SequenceNumber, h.ObservationDomainId)
 }
 
 // size returns the size of the TemplateFlowSet in bytes.

--- a/ipfix/ipfix_coverage_test.go
+++ b/ipfix/ipfix_coverage_test.go
@@ -8,10 +8,9 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
-	"os"
 	"testing"
+	"time"
 
-	"github.com/dmabry/flowgre/netflow"
 	"github.com/dmabry/flowgre/utils"
 )
 
@@ -21,11 +20,11 @@ import (
 
 func TestOptionsTemplateFlowSet_Generate(t *testing.T) {
 	t.Parallel()
-	session := netflow.NewSession()
-	otfs := new(OptionsTemplateFlowSet).Generate(session)
+	otfs := new(OptionsTemplateFlowSet).Generate(nil)
 
-	if otfs.FlowSetID != 0 {
-		t.Errorf("FlowSetID should be 0 for template FlowSets, got %d", otfs.FlowSetID)
+	// RFC 7011: Options Template Sets use Set ID 3
+	if otfs.FlowSetID != SetIDOptionsTemplate {
+		t.Errorf("FlowSetID should be %d for Options Template Sets, got %d", SetIDOptionsTemplate, otfs.FlowSetID)
 	}
 	if otfs.Template.TemplateID != 257 {
 		t.Errorf("TemplateID should be 257, got %d", otfs.Template.TemplateID)
@@ -33,37 +32,19 @@ func TestOptionsTemplateFlowSet_Generate(t *testing.T) {
 	if otfs.Template.ScopeFieldCount != 1 {
 		t.Errorf("ScopeFieldCount should be 1, got %d", otfs.Template.ScopeFieldCount)
 	}
-	if len(otfs.Template.ScopeFields) != 1 {
-		t.Fatalf("Expected 1 scope field, got %d", len(otfs.Template.ScopeFields))
+	if otfs.Template.FieldCount < 1 {
+		t.Errorf("FieldCount should be >= 1, got %d", otfs.Template.FieldCount)
 	}
-	if otfs.Template.ScopeFields[0].Type != ObservationDomainId {
+	if len(otfs.Template.Fields) != int(otfs.Template.FieldCount) {
+		t.Fatalf("Fields length should match FieldCount, got %d fields, %d count",
+			len(otfs.Template.Fields), otfs.Template.FieldCount)
+	}
+	if otfs.Template.Fields[0].Type != ObservationDomainId {
 		t.Errorf("Scope field type should be ObservationDomainId (%d), got %d",
-			ObservationDomainId, otfs.Template.ScopeFields[0].Type)
+			ObservationDomainId, otfs.Template.Fields[0].Type)
 	}
-	if otfs.Template.ScopeFields[0].Length != 4 {
-		t.Errorf("Scope field length should be 4, got %d", otfs.Template.ScopeFields[0].Length)
-	}
-	if otfs.Template.DataFieldCount != 2 {
-		t.Errorf("DataFieldCount should be 2, got %d", otfs.Template.DataFieldCount)
-	}
-	if len(otfs.Template.DataFields) != 2 {
-		t.Fatalf("Expected 2 data fields, got %d", len(otfs.Template.DataFields))
-	}
-	// Data field 0: ProcessName (variable-length, length=0 in template)
-	if otfs.Template.DataFields[0].Type != ProcessName {
-		t.Errorf("Data field[0] type should be ProcessName (%d), got %d",
-			ProcessName, otfs.Template.DataFields[0].Type)
-	}
-	if otfs.Template.DataFields[0].Length != 0 {
-		t.Errorf("Data field[0] length should be 0 (variable), got %d", otfs.Template.DataFields[0].Length)
-	}
-	// Data field 1: ProcessId
-	if otfs.Template.DataFields[1].Type != ProcessId {
-		t.Errorf("Data field[1] type should be ProcessId (%d), got %d",
-			ProcessId, otfs.Template.DataFields[1].Type)
-	}
-	if otfs.Template.DataFields[1].Length != 4 {
-		t.Errorf("Data field[1] length should be 4, got %d", otfs.Template.DataFields[1].Length)
+	if otfs.Template.Fields[0].Length != 4 {
+		t.Errorf("Scope field length should be 4, got %d", otfs.Template.Fields[0].Length)
 	}
 }
 
@@ -73,7 +54,7 @@ func TestOptionsTemplateFlowSet_Generate(t *testing.T) {
 
 func TestOptionsDataFlowSet_Generate(t *testing.T) {
 	t.Parallel()
-	odfs := new(OptionsDataFlowSet).Generate(42, "flowgre-test", 12345)
+	odfs := new(OptionsDataFlowSet).Generate(42)
 
 	if odfs.FlowSetID != 257 {
 		t.Errorf("FlowSetID should be 257 (matching Options TemplateID), got %d", odfs.FlowSetID)
@@ -85,13 +66,6 @@ func TestOptionsDataFlowSet_Generate(t *testing.T) {
 	if rec.ObservationDomainId != 42 {
 		t.Errorf("ObservationDomainId should be 42, got %d", rec.ObservationDomainId)
 	}
-	if rec.ProcessName != "flowgre-test" {
-		t.Errorf("ProcessName should be 'flowgre-test', got %q", rec.ProcessName)
-	}
-	if rec.ProcessId != 12345 {
-		t.Errorf("ProcessId should be 12345, got %d", rec.ProcessId)
-	}
-	// Length should be positive
 	if odfs.Length == 0 {
 		t.Error("Length should not be zero")
 	}
@@ -99,14 +73,14 @@ func TestOptionsDataFlowSet_Generate(t *testing.T) {
 
 func TestGenerateOptionsDataIPFIX(t *testing.T) {
 	t.Parallel()
-	session := netflow.NewSession()
-	flow := GenerateOptionsDataIPFIX(99, session)
+	seq := NewIPFIXSequence()
+	flow := GenerateOptionsDataIPFIX(99, seq)
 
 	if flow.Header.Version != 10 {
 		t.Errorf("Version should be 10, got %d", flow.Header.Version)
 	}
-	if flow.Header.SourceID != 99 {
-		t.Errorf("SourceID should be 99, got %d", flow.Header.SourceID)
+	if flow.Header.ObservationDomainId != 99 {
+		t.Errorf("ObservationDomainId should be 99, got %d", flow.Header.ObservationDomainId)
 	}
 	if len(flow.OptionsDataFlowSets) != 1 {
 		t.Fatalf("Expected 1 OptionsDataFlowSet, got %d", len(flow.OptionsDataFlowSets))
@@ -118,24 +92,14 @@ func TestGenerateOptionsDataIPFIX(t *testing.T) {
 	if len(odfs.Records) != 1 {
 		t.Fatalf("Expected 1 record, got %d", len(odfs.Records))
 	}
-	// Process name should contain "flowgre"
-	if odfs.Records[0].ProcessName == "" {
-		t.Error("ProcessName should not be empty")
-	}
-	// PID should match actual process
-	if odfs.Records[0].ProcessId != uint32(os.Getpid()) {
-		t.Errorf("ProcessId should match os.Getpid(), got %d want %d",
-			odfs.Records[0].ProcessId, os.Getpid())
-	}
 }
 
 func TestOptionsData_ToBytes(t *testing.T) {
 	t.Parallel()
-	session := netflow.NewSession()
-	flow := GenerateOptionsDataIPFIX(42, session)
-	buf := flow.ToBytes()
+	seq := NewIPFIXSequence()
+	flow := GenerateOptionsDataIPFIX(42, seq)
+	buf, _ := flow.ToBytes()
 
-	// Parse header
 	var header Header
 	if err := binary.Read(bytes.NewReader(buf.Bytes()), binary.BigEndian, &header); err != nil {
 		t.Fatalf("Failed to parse header: %v", err)
@@ -143,8 +107,8 @@ func TestOptionsData_ToBytes(t *testing.T) {
 	if header.Version != 10 {
 		t.Errorf("Parsed version should be 10, got %d", header.Version)
 	}
-	if header.SourceID != 42 {
-		t.Errorf("Parsed SourceID should be 42, got %d", header.SourceID)
+	if header.ObservationDomainId != 42 {
+		t.Errorf("Parsed ObservationDomainId should be 42, got %d", header.ObservationDomainId)
 	}
 }
 
@@ -169,8 +133,8 @@ func TestMinimalIPFIXProfile_TemplateFields(t *testing.T) {
 		t.Fatalf("Expected 7 fields, got %d", len(fields))
 	}
 	expected := []Field{
-		{Type: InOctets, Length: 4},
-		{Type: InPackets, Length: 4},
+		{Type: OctetDeltaCount, Length: 4},
+		{Type: PacketDeltaCount, Length: 4},
 		{Type: SourceIPv4Address, Length: 4},
 		{Type: DestinationIPv4Address, Length: 4},
 		{Type: SourceTransportPort, Length: 2},
@@ -188,9 +152,8 @@ func TestMinimalIPFIXFlow_Generate(t *testing.T) {
 	t.Parallel()
 	srcIP := net.ParseIP("10.0.0.1")
 	dstIP := net.ParseIP("10.0.0.2")
-	session := netflow.NewSession()
 
-	mf := new(MinimalIPFIXFlow).Generate(srcIP, dstIP, utils.HTTPSPort, session)
+	mf := new(MinimalIPFIXFlow).Generate(srcIP, dstIP, utils.HTTPSPort, nil)
 
 	if mf.SourceIPv4Addr == 0 {
 		t.Error("SourceIPv4Addr should not be zero")
@@ -204,11 +167,11 @@ func TestMinimalIPFIXFlow_Generate(t *testing.T) {
 	if mf.ProtocolIdentifier != utils.TCPProto {
 		t.Errorf("ProtocolIdentifier should be %d, got %d", utils.TCPProto, mf.ProtocolIdentifier)
 	}
-	if mf.InOctets == 0 {
-		t.Error("InOctets should not be zero")
+	if mf.OctetDeltaCount == 0 {
+		t.Error("OctetDeltaCount should not be zero")
 	}
-	if mf.InPackets == 0 {
-		t.Error("InPackets should not be zero")
+	if mf.PacketDeltaCount == 0 {
+		t.Error("PacketDeltaCount should not be zero")
 	}
 }
 
@@ -216,11 +179,9 @@ func TestMinimalIPFIXFlow_Generate_IPv6(t *testing.T) {
 	t.Parallel()
 	srcIP := net.ParseIP("2001:db8::1")
 	dstIP := net.ParseIP("2001:db8::2")
-	session := netflow.NewSession()
 
-	mf := new(MinimalIPFIXFlow).Generate(srcIP, dstIP, utils.HTTPSPort, session)
+	mf := new(MinimalIPFIXFlow).Generate(srcIP, dstIP, utils.HTTPSPort, nil)
 
-	// Minimal profile only has IPv4 fields — they should be zeroed for IPv6
 	if mf.SourceIPv4Addr != 0 {
 		t.Errorf("IPv4 src should be zeroed for IPv6 input, got %d", mf.SourceIPv4Addr)
 	}
@@ -233,7 +194,6 @@ func TestMinimalIPFIXFlow_Generate_AllProtocols(t *testing.T) {
 	t.Parallel()
 	srcIP := net.ParseIP("10.0.0.1")
 	dstIP := net.ParseIP("10.0.0.2")
-	session := netflow.NewSession()
 
 	cases := []struct {
 		port      int
@@ -245,12 +205,12 @@ func TestMinimalIPFIXFlow_Generate_AllProtocols(t *testing.T) {
 		{utils.DNSPort, uint16(utils.DNSPort), utils.UDPProto},
 		{utils.HTTPPort, uint16(utils.HTTPPort), utils.TCPProto},
 		{utils.HTTPSPort, uint16(utils.HTTPSPort), utils.TCPProto},
-		{99999, uint16(utils.HTTPSPort), utils.TCPProto}, // default
+		{99999, uint16(utils.HTTPSPort), utils.TCPProto},
 	}
 
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("port_%d", tc.port), func(t *testing.T) {
-			mf := new(MinimalIPFIXFlow).Generate(srcIP, dstIP, tc.port, session)
+			mf := new(MinimalIPFIXFlow).Generate(srcIP, dstIP, tc.port, nil)
 			if mf.DestPort != tc.wantPort {
 				t.Errorf("DestPort: got %d, want %d", mf.DestPort, tc.wantPort)
 			}
@@ -281,9 +241,8 @@ func TestExtendedIPFIXProfile_TemplateFields(t *testing.T) {
 	if len(fields) != 17 {
 		t.Fatalf("Expected 17 fields, got %d", len(fields))
 	}
-	// Check first and last fields
-	if fields[0].Type != InOctets {
-		t.Errorf("First field should be InOctets, got %d", fields[0].Type)
+	if fields[0].Type != OctetDeltaCount {
+		t.Errorf("First field should be OctetDeltaCount, got %d", fields[0].Type)
 	}
 	if fields[len(fields)-1].Type != DestinationIPv6Address {
 		t.Errorf("Last field should be DestinationIPv6Address, got %d", fields[len(fields)-1].Type)
@@ -309,14 +268,13 @@ func TestGenericIPFIXProfile_Name(t *testing.T) {
 func TestHeader_Size(t *testing.T) {
 	t.Parallel()
 	h := Header{
-		Version:      10,
-		FlowCount:    5,
-		SysUptime:    1000,
-		UnixSec:      1234567890,
-		FlowSequence: 42,
-		SourceID:     618,
+		Version:             10,
+		Length:              100,
+		ExportTime:          1234567890,
+		SequenceNumber:      42,
+		ObservationDomainId: 618,
 	}
-	want := binary.Size(Header{})
+	want := 16
 	got := h.size()
 	if got != want {
 		t.Errorf("Header.size(): got %d, want %d", got, want)
@@ -326,19 +284,17 @@ func TestHeader_Size(t *testing.T) {
 func TestHeader_String(t *testing.T) {
 	t.Parallel()
 	h := Header{
-		Version:      10,
-		FlowCount:    5,
-		SysUptime:    1000,
-		UnixSec:      1234567890,
-		FlowSequence: 42,
-		SourceID:     618,
+		Version:             10,
+		Length:              100,
+		ExportTime:          1234567890,
+		SequenceNumber:      42,
+		ObservationDomainId: 618,
 	}
 	s := h.String()
 	if s == "" {
 		t.Error("Header.String() should not be empty")
 	}
-	// Should contain key values
-	for _, substr := range []string{"Version: 10", "Count: 5", "SourceID: 618"} {
+	for _, substr := range []string{"Version: 10", "ObservationDomainId: 618"} {
 		if !bytes.Contains([]byte(s), []byte(substr)) {
 			t.Errorf("Header.String() should contain %q, got: %s", substr, s)
 		}
@@ -347,8 +303,7 @@ func TestHeader_String(t *testing.T) {
 
 func TestTemplateFlowSet_Size(t *testing.T) {
 	t.Parallel()
-	session := netflow.NewSession()
-	tfs := new(TemplateFlowSet).Generate(session)
+	tfs := new(TemplateFlowSet).Generate(nil)
 
 	size := tfs.size()
 	if size != int(tfs.Length) {
@@ -361,8 +316,7 @@ func TestTemplateFlowSet_Size(t *testing.T) {
 
 func TestDataFlowSet_Size(t *testing.T) {
 	t.Parallel()
-	session := netflow.NewSession()
-	dfs, err := new(DataFlowSet).Generate(5, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session)
+	dfs, err := new(DataFlowSet).Generate(5, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -378,8 +332,8 @@ func TestDataFlowSet_Size(t *testing.T) {
 
 func TestGetIPFIXSizes(t *testing.T) {
 	t.Parallel()
-	session := netflow.NewSession()
-	flow, err := GenerateIPFIX(5, 42, "10.0.0.0/8", "10.0.0.0/8", session)
+	seq := NewIPFIXSequence()
+	flow, err := GenerateIPFIX(5, 42, "10.0.0.0/8", "10.0.0.0/8", seq)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -401,7 +355,6 @@ func TestGetIPFIXSizes(t *testing.T) {
 
 func TestIsValidIPFIX_TooShort(t *testing.T) {
 	t.Parallel()
-	// Header is 20 bytes; a shorter payload should error
 	ok, err := IsValidIPFIX([]byte{10})
 	if ok {
 		t.Error("IsValidIPFIX should reject too-short payload")
@@ -424,14 +377,12 @@ func TestIsValidIPFIX_Empty(t *testing.T) {
 
 func TestIsValidIPFIX_RejectOtherVersions(t *testing.T) {
 	t.Parallel()
-	// Craft a 20-byte header with version 11
 	buf := new(bytes.Buffer)
-	binary.Write(buf, binary.BigEndian, uint16(11))         // version
-	binary.Write(buf, binary.BigEndian, uint16(1))          // flowCount
-	binary.Write(buf, binary.BigEndian, uint32(1000))       // sysUptime
-	binary.Write(buf, binary.BigEndian, uint32(1234567890)) // unixSec
-	binary.Write(buf, binary.BigEndian, uint32(1))          // flowSequence
-	binary.Write(buf, binary.BigEndian, uint32(42))         // sourceID
+	binary.Write(buf, binary.BigEndian, uint16(11))
+	binary.Write(buf, binary.BigEndian, uint16(16))
+	binary.Write(buf, binary.BigEndian, uint32(1234567890))
+	binary.Write(buf, binary.BigEndian, uint32(1))
+	binary.Write(buf, binary.BigEndian, uint32(42))
 
 	ok, err := IsValidIPFIX(buf.Bytes())
 	if ok {
@@ -439,6 +390,83 @@ func TestIsValidIPFIX_RejectOtherVersions(t *testing.T) {
 	}
 	if err == nil {
 		t.Error("IsValidIPFIX should return error for version 11")
+	}
+}
+
+func TestIsValidIPFIX_RejectReservedSetIDs(t *testing.T) {
+	t.Parallel()
+	buf := new(bytes.Buffer)
+	binary.Write(buf, binary.BigEndian, uint16(10))
+	binary.Write(buf, binary.BigEndian, uint16(20))
+	binary.Write(buf, binary.BigEndian, uint32(1234567890))
+	binary.Write(buf, binary.BigEndian, uint32(1))
+	binary.Write(buf, binary.BigEndian, uint32(42))
+	binary.Write(buf, binary.BigEndian, uint16(0))
+	binary.Write(buf, binary.BigEndian, uint16(4))
+
+	ok, err := IsValidIPFIX(buf.Bytes())
+	if ok {
+		t.Error("IsValidIPFIX should reject reserved Set ID 0")
+	}
+	if err == nil {
+		t.Error("IsValidIPFIX should return error for reserved Set ID")
+	}
+}
+
+func TestIsValidIPFIX_RejectUnassignedSetIDs(t *testing.T) {
+	t.Parallel()
+	buf := new(bytes.Buffer)
+	binary.Write(buf, binary.BigEndian, uint16(10))
+	binary.Write(buf, binary.BigEndian, uint16(20))
+	binary.Write(buf, binary.BigEndian, uint32(1234567890))
+	binary.Write(buf, binary.BigEndian, uint32(1))
+	binary.Write(buf, binary.BigEndian, uint32(42))
+	binary.Write(buf, binary.BigEndian, uint16(100))
+	binary.Write(buf, binary.BigEndian, uint16(4))
+
+	ok, err := IsValidIPFIX(buf.Bytes())
+	if ok {
+		t.Error("IsValidIPFIX should reject unassigned Set ID 100")
+	}
+	if err == nil {
+		t.Error("IsValidIPFIX should return error for unassigned Set ID")
+	}
+}
+
+func TestIsValidIPFIX_MessageLengthMismatch(t *testing.T) {
+	t.Parallel()
+	buf := new(bytes.Buffer)
+	binary.Write(buf, binary.BigEndian, uint16(10))
+	binary.Write(buf, binary.BigEndian, uint16(100))
+	binary.Write(buf, binary.BigEndian, uint32(1234567890))
+	binary.Write(buf, binary.BigEndian, uint32(1))
+	binary.Write(buf, binary.BigEndian, uint32(42))
+
+	ok, err := IsValidIPFIX(buf.Bytes())
+	if ok {
+		t.Error("IsValidIPFIX should reject length mismatch")
+	}
+	if err == nil {
+		t.Error("IsValidIPFIX should return error for length mismatch")
+	}
+}
+
+func TestIsValidIPFIX_RejectTrailingData(t *testing.T) {
+	t.Parallel()
+	buf := new(bytes.Buffer)
+	binary.Write(buf, binary.BigEndian, uint16(10))
+	binary.Write(buf, binary.BigEndian, uint16(16))
+	binary.Write(buf, binary.BigEndian, uint32(1234567890))
+	binary.Write(buf, binary.BigEndian, uint32(1))
+	binary.Write(buf, binary.BigEndian, uint32(42))
+	buf.Write([]byte{0, 0, 0, 0})
+
+	ok, err := IsValidIPFIX(buf.Bytes())
+	if ok {
+		t.Error("IsValidIPFIX should reject trailing data")
+	}
+	if err == nil {
+		t.Error("IsValidIPFIX should return error for trailing data")
 	}
 }
 
@@ -464,12 +492,12 @@ func TestUpdateTimeStamp_Empty(t *testing.T) {
 
 func TestUpdateTimeStamp_PreservesPayload(t *testing.T) {
 	t.Parallel()
-	session := netflow.NewSession()
-	flow, err := GenerateDataIPFIX(3, 42, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session)
+	seq := NewIPFIXSequence()
+	flow, err := GenerateDataIPFIX(3, 42, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, seq)
 	if err != nil {
 		t.Fatal(err)
 	}
-	buf := flow.ToBytes()
+	buf, _ := flow.ToBytes()
 	original := buf.Bytes()
 
 	updated, err := UpdateTimeStamp(original)
@@ -477,15 +505,13 @@ func TestUpdateTimeStamp_PreservesPayload(t *testing.T) {
 		t.Fatalf("UpdateTimeStamp error: %v", err)
 	}
 
-	// Length should be the same
 	if len(updated) != len(original) {
 		t.Errorf("UpdateTimeStamp changed payload length: got %d, want %d", len(updated), len(original))
 	}
 
-	// Only the UnixSec field (bytes 8-11) should differ
 	for i := 0; i < len(original); i++ {
-		if i >= 8 && i < 12 {
-			continue // timestamp bytes may differ
+		if i >= 4 && i < 8 {
+			continue
 		}
 		if updated[i] != original[i] {
 			t.Errorf("Byte[%d] changed unexpectedly: got 0x%02x, want 0x%02x",
@@ -500,11 +526,11 @@ func TestUpdateTimeStamp_PreservesPayload(t *testing.T) {
 
 func TestToBytes_OptionsData_BufferLengthMatchesFlowSetLengths(t *testing.T) {
 	t.Parallel()
-	session := netflow.NewSession()
-	flow := GenerateOptionsDataIPFIX(42, session)
-	buf := flow.ToBytes()
+	seq := NewIPFIXSequence()
+	flow := GenerateOptionsDataIPFIX(42, seq)
+	buf, _ := flow.ToBytes()
 
-	expectedLen := binary.Size(flow.Header)
+	expectedLen := 16
 	for _, fs := range flow.OptionsDataFlowSets {
 		expectedLen += int(fs.Length)
 	}
@@ -519,13 +545,11 @@ func TestToBytes_OptionsData_BufferLengthMatchesFlowSetLengths(t *testing.T) {
 
 func TestOptionsTemplateAndData_RoundTrip(t *testing.T) {
 	t.Parallel()
-	session := netflow.NewSession()
+	seq := NewIPFIXSequence()
 
-	// Generate options template
-	tFlow := GenerateTemplateIPFIX(100, session)
-	tBuf := tFlow.ToBytes()
+	tFlow := GenerateTemplateIPFIX(100, seq)
+	tBuf, _ := tFlow.ToBytes()
 
-	// Parse and verify Options Template was serialized
 	reader := bytes.NewReader(tBuf.Bytes())
 	var header Header
 	if err := binary.Read(reader, binary.BigEndian, &header); err != nil {
@@ -535,7 +559,6 @@ func TestOptionsTemplateAndData_RoundTrip(t *testing.T) {
 		t.Fatalf("Expected version 10, got %d", header.Version)
 	}
 
-	// Read flow sets
 	foundTemplate := false
 	foundOptionsTemplate := false
 	for reader.Len() > 0 {
@@ -552,23 +575,21 @@ func TestOptionsTemplateAndData_RoundTrip(t *testing.T) {
 		if err := binary.Read(reader, binary.BigEndian, &templateID); err != nil {
 			break
 		}
-		remaining -= 2
 
-		if templateID == 256 {
+		if flowSetID == SetIDTemplate && templateID == 256 {
 			foundTemplate = true
-		} else if templateID == 257 {
+		} else if flowSetID == SetIDOptionsTemplate && templateID == 257 {
 			foundOptionsTemplate = true
 		}
 
-		// Skip remaining bytes in this flow set
-		reader.Seek(int64(remaining), 1)
+		reader.Seek(int64(remaining-2), 1)
 	}
 
 	if !foundTemplate {
-		t.Error("Expected to find regular template (ID 256)")
+		t.Error("Expected to find regular template (Set ID 2, Template ID 256)")
 	}
 	if !foundOptionsTemplate {
-		t.Error("Expected to find options template (ID 257)")
+		t.Error("Expected to find options template (Set ID 3, Template ID 257)")
 	}
 }
 
@@ -578,8 +599,7 @@ func TestOptionsTemplateAndData_RoundTrip(t *testing.T) {
 
 func TestDataFlowSet_Generate_ZeroFlowCount(t *testing.T) {
 	t.Parallel()
-	session := netflow.NewSession()
-	dfs, err := new(DataFlowSet).Generate(0, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session)
+	dfs, err := new(DataFlowSet).Generate(0, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -587,7 +607,6 @@ func TestDataFlowSet_Generate_ZeroFlowCount(t *testing.T) {
 	if len(dfs.Items) != 0 {
 		t.Errorf("Expected 0 items, got %d", len(dfs.Items))
 	}
-	// Length should still be FlowSetID(2) + Length(2) = 4, possibly with padding
 	if dfs.Length < 4 {
 		t.Errorf("Length should be at least 4, got %d", dfs.Length)
 	}
@@ -597,7 +616,6 @@ func TestGenericFlow_Generate_AllProtocols(t *testing.T) {
 	t.Parallel()
 	srcIP := net.ParseIP("10.0.0.1")
 	dstIP := net.ParseIP("10.0.0.2")
-	session := netflow.NewSession()
 
 	cases := []struct {
 		port      int
@@ -617,12 +635,12 @@ func TestGenericFlow_Generate_AllProtocols(t *testing.T) {
 		{utils.HTTPSAltPort, uint16(utils.HTTPSAltPort), utils.TCPProto},
 		{utils.P2PPort, uint16(utils.P2PPort), utils.TCPProto},
 		{utils.BTPort, uint16(utils.BTPort), utils.TCPProto},
-		{99999, uint16(utils.HTTPSPort), utils.TCPProto}, // default
+		{99999, uint16(utils.HTTPSPort), utils.TCPProto},
 	}
 
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("port_%d", tc.port), func(t *testing.T) {
-			gf := new(GenericFlow).Generate(srcIP, dstIP, tc.port, session)
+			gf := new(GenericFlow).Generate(srcIP, dstIP, tc.port, nil)
 			if gf.DestPort != tc.wantPort {
 				t.Errorf("DestPort: got %d, want %d", gf.DestPort, tc.wantPort)
 			}
@@ -641,5 +659,32 @@ func TestVersion_Constant(t *testing.T) {
 	t.Parallel()
 	if Version != 10 {
 		t.Errorf("IPFIX Version should be 10, got %d", Version)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GenericFlow timestamp fields are uint64
+// ---------------------------------------------------------------------------
+
+func TestGenericFlow_EpochMilliseconds(t *testing.T) {
+	t.Parallel()
+	srcIP := net.ParseIP("10.0.0.1")
+	dstIP := net.ParseIP("10.0.0.2")
+
+	gf := new(GenericFlow).Generate(srcIP, dstIP, utils.HTTPSPort, nil)
+
+	nowMillis := uint64(time.Now().UnixMilli())
+	if gf.FlowStartMillis == 0 {
+		t.Error("FlowStartMillis should not be zero")
+	}
+	if gf.FlowEndMillis == 0 {
+		t.Error("FlowEndMillis should not be zero")
+	}
+	if gf.FlowStartMillis > nowMillis+1000 || gf.FlowStartMillis < nowMillis-1000 {
+		t.Errorf("FlowStartMillis %d is not close to current epoch millis %d",
+			gf.FlowStartMillis, nowMillis)
+	}
+	if gf.FlowEndMillis < gf.FlowStartMillis {
+		t.Errorf("FlowEndMillis %d < FlowStartMillis %d", gf.FlowEndMillis, gf.FlowStartMillis)
 	}
 }

--- a/ipfix/ipfix_test.go
+++ b/ipfix/ipfix_test.go
@@ -17,44 +17,41 @@ import (
 
 func TestHeader_Generate(t *testing.T) {
 	t.Parallel()
-	flowCount := 10
 	sourceID := 618
-	session := netflow.NewSession()
-	header := new(Header).Generate(flowCount, sourceID, session)
+	header := new(Header).Generate(sourceID, 42)
 
 	if header.Version != 10 {
 		t.Errorf("Header returned wrong version! Got: %d Want: 10", header.Version)
 	}
-	if header.SysUptime == 0 {
-		t.Error("Header SysUptime should not be zero")
+	if header.ExportTime == 0 {
+		t.Error("Header ExportTime should not be zero")
 	}
-	if header.FlowCount != uint16(flowCount) {
-		t.Errorf("Header FlowCount wrong! Got: %d Want: %d", header.FlowCount, flowCount)
+	if header.SequenceNumber != 42 {
+		t.Errorf("Header SequenceNumber wrong! Got: %d Want: 42", header.SequenceNumber)
 	}
-	if header.UnixSec == 0 {
-		t.Error("Header UnixSec should not be zero")
+	if header.ObservationDomainId != uint32(sourceID) {
+		t.Errorf("Header ObservationDomainId wrong! Got: %d Want: %d", header.ObservationDomainId, sourceID)
 	}
-	if header.FlowSequence == 0 {
-		t.Error("Header FlowSequence should not be zero")
-	}
-	if header.SourceID != uint32(sourceID) {
-		t.Errorf("Header SourceID wrong! Got: %d Want: %d", header.SourceID, sourceID)
+	// Header is 16 bytes per RFC 7011
+	if binary.Size(header) != 16 {
+		t.Errorf("Header size wrong! Got: %d Want: 16", binary.Size(header))
 	}
 }
 
 func TestGenerateTemplateIPFIX(t *testing.T) {
 	t.Parallel()
 	sourceID := 618
-	session := netflow.NewSession()
-	flow := GenerateTemplateIPFIX(sourceID, session)
+	seq := NewIPFIXSequence()
+	flow := GenerateTemplateIPFIX(sourceID, seq)
 
 	if len(flow.TemplateFlowSets) < 1 {
 		t.Fatal("No template flowsets generated")
 	}
 
 	for _, tFlow := range flow.TemplateFlowSets {
-		if tFlow.FlowSetID != 0 {
-			t.Errorf("FlowSetID wrong! Got: %d Want: 0", tFlow.FlowSetID)
+		// RFC 7011: Template Sets use Set ID 2
+		if tFlow.FlowSetID != SetIDTemplate {
+			t.Errorf("FlowSetID wrong! Got: %d Want: %d", tFlow.FlowSetID, SetIDTemplate)
 		}
 		// Template: FlowSetID(2)+Length(2)+TemplateID(2)+FieldCount(2)+19*(Type(2)+Length(2))=84, no padding
 		if tFlow.Length != 84 {
@@ -75,8 +72,8 @@ func TestGenerateDataIPFIX(t *testing.T) {
 	t.Parallel()
 	flowCount := 10
 	sourceID := 618
-	session := netflow.NewSession()
-	flow, err := GenerateDataIPFIX(flowCount, sourceID, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session)
+	seq := NewIPFIXSequence()
+	flow, err := GenerateDataIPFIX(flowCount, sourceID, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, seq)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -102,8 +99,8 @@ func TestGenerateIPFIX(t *testing.T) {
 	t.Parallel()
 	flowCount := 10
 	sourceID := 618
-	session := netflow.NewSession()
-	flow, err := GenerateIPFIX(flowCount, sourceID, "10.0.0.0/8", "10.0.0.0/8", session)
+	seq := NewIPFIXSequence()
+	flow, err := GenerateIPFIX(flowCount, sourceID, "10.0.0.0/8", "10.0.0.0/8", seq)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,8 +114,15 @@ func TestGenerateIPFIX(t *testing.T) {
 	if len(flow.DataFlowSets) < 1 {
 		t.Error("Should have data flowsets")
 	}
-	if flow.Header.FlowCount != uint16(flowCount+1) {
-		t.Errorf("FlowCount wrong! Got: %d Want: %d", flow.Header.FlowCount, flowCount+1)
+
+	// Length is set during ToBytes; verify it's correct after serialization
+	buf, _ := flow.ToBytes()
+	parsedLen := binary.BigEndian.Uint16(buf.Bytes()[2:4])
+	if parsedLen == 0 {
+		t.Error("Header Length should not be zero after ToBytes")
+	}
+	if int(parsedLen) != buf.Len() {
+		t.Errorf("Header Length %d does not match buffer length %d", parsedLen, buf.Len())
 	}
 }
 
@@ -126,16 +130,16 @@ func TestToBytes_RoundTrip(t *testing.T) {
 	t.Parallel()
 	sourceID := 618
 	flowCount := 10
-	session := netflow.NewSession()
+	seq := NewIPFIXSequence()
 
-	tFlow := GenerateTemplateIPFIX(sourceID, session)
-	dFlow, err := GenerateDataIPFIX(flowCount, sourceID, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session)
+	tFlow := GenerateTemplateIPFIX(sourceID, seq)
+	dFlow, err := GenerateDataIPFIX(flowCount, sourceID, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, seq)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	tBuf := tFlow.ToBytes()
-	dBuf := dFlow.ToBytes()
+	tBuf, _ := tFlow.ToBytes()
+	dBuf, _ := dFlow.ToBytes()
 
 	// Verify Bytes match generated IPFIX Data
 	tLength := tBuf.Len()
@@ -157,16 +161,16 @@ func TestToBytes_RoundTrip(t *testing.T) {
 		t.Errorf("Returned invalid IPFIX Data buffer length! Got: %d Want: %d", dn, dBuf.Len())
 	}
 
-	// Parse Template
+	// Parse Template - RFC 7011 16-byte header
 	tparsed := IPFIX{}
 	treader := bytes.NewReader(tread)
 	err = binary.Read(treader, binary.BigEndian, &tparsed.Header)
 	if err != nil {
 		t.Errorf("Failed to parse IPFIX Header! Got: %v", err)
 	}
-	if int(tparsed.Header.SourceID) != sourceID {
-		t.Errorf("Failed to parse IPFIX Header Source ID! Got: %d Want: %d",
-			int(tparsed.Header.SourceID), sourceID)
+	if int(tparsed.Header.ObservationDomainId) != sourceID {
+		t.Errorf("Failed to parse IPFIX Header Observation Domain ID! Got: %d Want: %d",
+			int(tparsed.Header.ObservationDomainId), sourceID)
 	}
 	if tparsed.Header.Version != 10 {
 		t.Errorf("Failed to parse IPFIX Header Version! Got: %d Want: 10", tparsed.Header.Version)
@@ -178,17 +182,12 @@ func TestToBytes_RoundTrip(t *testing.T) {
 		if err := binary.Read(treader, binary.BigEndian, &flowSetID); err != nil {
 			break
 		}
-		if flowSetID != 0 {
-			// Not a template FlowSet, skip
-			break
-		}
 		var fsLength uint16
 		if err := binary.Read(treader, binary.BigEndian, &fsLength); err != nil {
 			break
 		}
-		remaining := int(fsLength) - 4 // subtract FlowSetID + Length
+		remaining := int(fsLength) - 4
 
-		// Check if this is an Options Template (TemplateID >= 256 with ScopeFieldCount)
 		var templateID uint16
 		if err := binary.Read(treader, binary.BigEndian, &templateID); err != nil {
 			break
@@ -196,27 +195,20 @@ func TestToBytes_RoundTrip(t *testing.T) {
 		remaining -= 2
 
 		if templateID == 257 {
-			// Options Template - parse it
+			// Options Template - RFC 7011 layout: TemplateID + FieldCount + ScopeFieldCount + fields
+			var fieldCount uint16
+			if err := binary.Read(treader, binary.BigEndian, &fieldCount); err != nil {
+				break
+			}
+			remaining -= 2
 			var scopeFieldCount uint16
 			if err := binary.Read(treader, binary.BigEndian, &scopeFieldCount); err != nil {
 				break
 			}
 			remaining -= 2
-			scopeFields := make([]Field, scopeFieldCount)
-			for i := range scopeFieldCount {
-				if err := binary.Read(treader, binary.BigEndian, &scopeFields[i]); err != nil {
-					break
-				}
-				remaining -= 4
-			}
-			var dataFieldCount uint16
-			if err := binary.Read(treader, binary.BigEndian, &dataFieldCount); err != nil {
-				break
-			}
-			remaining -= 2
-			dataFields := make([]Field, dataFieldCount)
-			for i := range dataFieldCount {
-				if err := binary.Read(treader, binary.BigEndian, &dataFields[i]); err != nil {
+			fields := make([]Field, fieldCount)
+			for i := range fieldCount {
+				if err := binary.Read(treader, binary.BigEndian, &fields[i]); err != nil {
 					break
 				}
 				remaining -= 4
@@ -226,19 +218,17 @@ func TestToBytes_RoundTrip(t *testing.T) {
 				Length:    fsLength,
 				Template: OptionsTemplate{
 					TemplateID:      templateID,
+					FieldCount:      fieldCount,
 					ScopeFieldCount: scopeFieldCount,
-					ScopeFields:     scopeFields,
-					DataFieldCount:  dataFieldCount,
-					DataFields:      dataFields,
+					Fields:          fields,
 				},
 				Padding: remaining,
 			})
-			// Skip padding
 			if remaining > 0 {
 				treader.Seek(int64(remaining), 1)
 			}
 		} else {
-			// Regular Data Template
+			// Regular Template
 			var fieldCount uint16
 			if err := binary.Read(treader, binary.BigEndian, &fieldCount); err != nil {
 				break
@@ -262,7 +252,6 @@ func TestToBytes_RoundTrip(t *testing.T) {
 				Padding: remaining,
 			}
 			tparsed.TemplateFlowSets = append(tparsed.TemplateFlowSets, tFlowSet)
-			// Skip padding
 			if remaining > 0 {
 				treader.Seek(int64(remaining), 1)
 			}
@@ -270,7 +259,16 @@ func TestToBytes_RoundTrip(t *testing.T) {
 	}
 
 	if !cmp.Equal(tFlow, tparsed) {
-		t.Error("Failed: Generated IPFIX Template Flow and Parsed are different!")
+		t.Log("Generated IPFIX Template Flow and Parsed are different!")
+		t.Logf("Original Header: %+v", tFlow.Header)
+		t.Logf("Parsed Header: %+v", tparsed.Header)
+		// Header.Length is set during ToBytes, so set it before comparing
+		tFlow.Header.Length = tparsed.Header.Length
+		if !cmp.Equal(tFlow, tparsed) {
+			t.Error("Failed: Generated IPFIX Template Flow and Parsed are different (after Length fix)!")
+		} else {
+			t.Log("Generated IPFIX Template Flow and Parsed Match!")
+		}
 	} else {
 		t.Log("Generated IPFIX Template Flow and Parsed Match!")
 	}
@@ -282,9 +280,9 @@ func TestToBytes_RoundTrip(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to parse IPFIX Data Header! Got: %v", err)
 	}
-	if int(dparsed.Header.SourceID) != sourceID {
-		t.Errorf("Failed to parse IPFIX Data Header Source ID! Got: %d Want: %d",
-			int(dparsed.Header.SourceID), sourceID)
+	if int(dparsed.Header.ObservationDomainId) != sourceID {
+		t.Errorf("Failed to parse IPFIX Data Header Observation Domain ID! Got: %d Want: %d",
+			int(dparsed.Header.ObservationDomainId), sourceID)
 	}
 	if dparsed.Header.Version != 10 {
 		t.Errorf("Failed to parse IPFIX Data Header Version! Got: %d Want: 10", dparsed.Header.Version)
@@ -324,7 +322,14 @@ func TestToBytes_RoundTrip(t *testing.T) {
 	dparsed.DataFlowSets = append(dparsed.DataFlowSets, *dFlowSet)
 
 	if !cmp.Equal(dFlow, dparsed) {
-		t.Error("Failed: Generated IPFIX Data Flow and Parsed are different!")
+		t.Log("Generated IPFIX Data Flow and Parsed are different!")
+		// Header.Length is set during ToBytes, so set it before comparing
+		dFlow.Header.Length = dparsed.Header.Length
+		if !cmp.Equal(dFlow, dparsed) {
+			t.Error("Failed: Generated IPFIX Data Flow and Parsed are different (after Length fix)!")
+		} else {
+			t.Log("Generated IPFIX Data Flow and Parsed Match!")
+		}
 	} else {
 		t.Log("Generated IPFIX Data Flow and Parsed Match!")
 	}
@@ -332,9 +337,9 @@ func TestToBytes_RoundTrip(t *testing.T) {
 
 func TestIsValidIPFIX_AcceptVersion10(t *testing.T) {
 	t.Parallel()
-	session := netflow.NewSession()
-	flow := GenerateTemplateIPFIX(100, session)
-	buf := flow.ToBytes()
+	seq := NewIPFIXSequence()
+	flow := GenerateTemplateIPFIX(100, seq)
+	buf, _ := flow.ToBytes()
 
 	ok, err := IsValidIPFIX(buf.Bytes())
 	if err != nil {
@@ -362,9 +367,9 @@ func TestIsValidIPFIX_RejectVersion9(t *testing.T) {
 
 func TestUpdateTimeStamp(t *testing.T) {
 	t.Parallel()
-	session := netflow.NewSession()
-	flow := GenerateTemplateIPFIX(100, session)
-	buf := flow.ToBytes()
+	seq := NewIPFIXSequence()
+	flow := GenerateTemplateIPFIX(100, seq)
+	buf, _ := flow.ToBytes()
 
 	before := time.Now().Unix()
 	time.Sleep(10 * time.Millisecond)
@@ -379,9 +384,9 @@ func TestUpdateTimeStamp(t *testing.T) {
 		t.Fatalf("Failed to parse updated header: %v", err)
 	}
 
-	if header.UnixSec < uint32(before) {
+	if header.ExportTime < uint32(before) {
 		t.Errorf("Updated timestamp should be >= current time. Got: %d Want: >= %d",
-			header.UnixSec, before)
+			header.ExportTime, before)
 	}
 	if header.Version != 10 {
 		t.Errorf("Updated header version should still be 10. Got: %d", header.Version)
@@ -390,27 +395,27 @@ func TestUpdateTimeStamp(t *testing.T) {
 
 func TestFlowSequenceMonotonicallyIncreases(t *testing.T) {
 	t.Parallel()
-	session := netflow.NewSession()
-	f1, err := GenerateDataIPFIX(1, 42, "10.0.0.0/8", "10.0.0.0/8", 443, session)
+	seq := NewIPFIXSequence()
+	f1, err := GenerateDataIPFIX(1, 42, "10.0.0.0/8", "10.0.0.0/8", 443, seq)
 	if err != nil {
 		t.Fatal(err)
 	}
-	f2, err := GenerateDataIPFIX(1, 42, "10.0.0.0/8", "10.0.0.0/8", 443, session)
+	f2, err := GenerateDataIPFIX(1, 42, "10.0.0.0/8", "10.0.0.0/8", 443, seq)
 	if err != nil {
 		t.Fatal(err)
 	}
-	f3, err := GenerateDataIPFIX(1, 42, "10.0.0.0/8", "10.0.0.0/8", 443, session)
+	f3, err := GenerateDataIPFIX(1, 42, "10.0.0.0/8", "10.0.0.0/8", 443, seq)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if f1.Header.FlowSequence >= f2.Header.FlowSequence {
-		t.Errorf("FlowSequence not monotonically increasing: f1=%d >= f2=%d",
-			f1.Header.FlowSequence, f2.Header.FlowSequence)
+	if f1.Header.SequenceNumber >= f2.Header.SequenceNumber {
+		t.Errorf("SequenceNumber not monotonically increasing: f1=%d >= f2=%d",
+			f1.Header.SequenceNumber, f2.Header.SequenceNumber)
 	}
-	if f2.Header.FlowSequence >= f3.Header.FlowSequence {
-		t.Errorf("FlowSequence not monotonically increasing: f2=%d >= f3=%d",
-			f2.Header.FlowSequence, f3.Header.FlowSequence)
+	if f2.Header.SequenceNumber >= f3.Header.SequenceNumber {
+		t.Errorf("SequenceNumber not monotonically increasing: f2=%d >= f3=%d",
+			f2.Header.SequenceNumber, f3.Header.SequenceNumber)
 	}
 }
 
@@ -418,12 +423,12 @@ func TestToBytes_BufferLengthMatchesFlowSetLengths(t *testing.T) {
 	t.Parallel()
 	sourceID := 618
 	flowCount := 10
-	session := netflow.NewSession()
+	seq := NewIPFIXSequence()
 
 	// Test template-only packet
-	tFlow := GenerateTemplateIPFIX(sourceID, session)
-	tBuf := tFlow.ToBytes()
-	expectedTLen := binary.Size(tFlow.Header)
+	tFlow := GenerateTemplateIPFIX(sourceID, seq)
+	tBuf, _ := tFlow.ToBytes()
+	expectedTLen := 16 // RFC 7011 header is 16 bytes
 	for _, fs := range tFlow.TemplateFlowSets {
 		expectedTLen += int(fs.Length)
 	}
@@ -432,33 +437,33 @@ func TestToBytes_BufferLengthMatchesFlowSetLengths(t *testing.T) {
 	}
 	if tBuf.Len() != expectedTLen {
 		t.Errorf("Template buffer length mismatch: got %d, want %d (header %d + flowsets %d)",
-			tBuf.Len(), expectedTLen, binary.Size(tFlow.Header),
-			expectedTLen-binary.Size(tFlow.Header))
+			tBuf.Len(), expectedTLen, 16,
+			expectedTLen-16)
 	}
 
 	// Test data-only packet
-	dFlow, err := GenerateDataIPFIX(flowCount, sourceID, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session)
+	dFlow, err := GenerateDataIPFIX(flowCount, sourceID, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, seq)
 	if err != nil {
 		t.Fatal(err)
 	}
-	dBuf := dFlow.ToBytes()
-	expectedDLen := binary.Size(dFlow.Header)
+	dBuf, _ := dFlow.ToBytes()
+	expectedDLen := 16
 	for _, fs := range dFlow.DataFlowSets {
 		expectedDLen += int(fs.Length)
 	}
 	if dBuf.Len() != expectedDLen {
 		t.Errorf("Data buffer length mismatch: got %d, want %d (header %d + flowsets %d)",
-			dBuf.Len(), expectedDLen, binary.Size(dFlow.Header),
-			expectedDLen-binary.Size(dFlow.Header))
+			dBuf.Len(), expectedDLen, 16,
+			expectedDLen-16)
 	}
 
 	// Test combined packet
-	cFlow, err := GenerateIPFIX(flowCount, sourceID, "10.0.0.0/8", "10.0.0.0/8", session)
+	cFlow, err := GenerateIPFIX(flowCount, sourceID, "10.0.0.0/8", "10.0.0.0/8", seq)
 	if err != nil {
 		t.Fatal(err)
 	}
-	cBuf := cFlow.ToBytes()
-	expectedCLen := binary.Size(cFlow.Header)
+	cBuf, _ := cFlow.ToBytes()
+	expectedCLen := 16
 	for _, fs := range cFlow.TemplateFlowSets {
 		expectedCLen += int(fs.Length)
 	}
@@ -480,27 +485,27 @@ func TestGetTemplateFields_IPFIXFieldTypes(t *testing.T) {
 		t.Fatalf("Field count wrong! Got: %d Want: 19", len(fields))
 	}
 
-	// Expected IPFIX field types (IANA IPFIX Information Model RFC 7011)
+	// Expected IANA IPFIX field types (RFC 7011)
 	expectedTypes := []uint16{
-		1026, // inOctets
-		1028, // outOctets
-		1025, // inPackets
-		1027, // outPackets
-		8,    // sourceIPv4Address
-		12,   // destinationIPv4Address
-		25,   // sourceIPv6Address
-		26,   // destinationIPv6Address
-		47,   // sourceIPv6PrefixLength
-		48,   // destinationIPv6PrefixLength
-		7,    // sourceTransportPort
-		11,   // destinationTransportPort
-		4,    // protocolIdentifier
-		6,    // tcpFlags
-		152,  // flowStartMilliseconds
-		153,  // flowEndMilliseconds
-		1024, // flowDirection
-		3,    // ipClassOfService
-		157,  // flowEndReason
+		1,   // octetDeltaCount
+		23,  // postOctetDeltaCount
+		2,   // packetDeltaCount
+		24,  // postPacketDeltaCount
+		8,   // sourceIPv4Address
+		12,  // destinationIPv4Address
+		27,  // sourceIPv6Address
+		28,  // destinationIPv6Address
+		29,  // sourceIPv6PrefixLength
+		30,  // destinationIPv6PrefixLength
+		7,   // sourceTransportPort
+		11,  // destinationTransportPort
+		4,   // protocolIdentifier
+		6,   // tcpControlBits
+		152, // flowStartMilliseconds
+		153, // flowEndMilliseconds
+		61,  // flowDirection
+		5,   // ipClassOfService
+		136, // flowEndReason
 	}
 
 	for i, expected := range expectedTypes {
@@ -509,8 +514,8 @@ func TestGetTemplateFields_IPFIXFieldTypes(t *testing.T) {
 		}
 	}
 
-	// Verify field lengths match expected sizes
-	expectedLengths := []uint16{4, 4, 4, 4, 4, 4, 16, 16, 1, 1, 2, 2, 1, 1, 4, 4, 1, 1, 1}
+	// Verify field lengths - timestamps are now 8 bytes
+	expectedLengths := []uint16{4, 4, 4, 4, 4, 4, 16, 16, 1, 1, 2, 2, 1, 1, 8, 8, 1, 1, 1}
 	for i, expected := range expectedLengths {
 		if fields[i].Length != expected {
 			t.Errorf("Field[%d] length wrong! Got: %d Want: %d", i, fields[i].Length, expected)
@@ -523,11 +528,9 @@ func TestGenericFlowIPv6(t *testing.T) {
 
 	srcIP := net.ParseIP("2001:db8::1")
 	dstIP := net.ParseIP("2001:db8::2")
-	session := netflow.NewSession()
 
-	result := new(GenericFlow).Generate(srcIP, dstIP, utils.HTTPSPort, session)
+	result := new(GenericFlow).Generate(srcIP, dstIP, utils.HTTPSPort, nil)
 
-	// IPv4 fields should be zeroed
 	if result.SourceIPv4Addr != 0 {
 		t.Errorf("expected zeroed IPv4 src, got %d", result.SourceIPv4Addr)
 	}
@@ -535,7 +538,6 @@ func TestGenericFlowIPv6(t *testing.T) {
 		t.Errorf("expected zeroed IPv4 dst, got %d", result.DestIPv4Addr)
 	}
 
-	// IPv6 fields should be populated
 	expectedSrc := [16]byte{}
 	copy(expectedSrc[:], srcIP.To16())
 	if result.SourceIPv6Addr != expectedSrc {
@@ -547,7 +549,6 @@ func TestGenericFlowIPv6(t *testing.T) {
 		t.Errorf("IPv6 dst mismatch: got %v want %v", result.DestIPv6Addr, expectedDst)
 	}
 
-	// Prefix should be 64
 	if result.SourceIPv6Prefix != 64 {
 		t.Errorf("expected IPv6 src prefix 64, got %d", result.SourceIPv6Prefix)
 	}
@@ -561,11 +562,9 @@ func TestGenericFlowIPv4_ZerosIPv6(t *testing.T) {
 
 	srcIP := net.ParseIP("10.0.0.1")
 	dstIP := net.ParseIP("10.0.0.2")
-	session := netflow.NewSession()
 
-	result := new(GenericFlow).Generate(srcIP, dstIP, utils.HTTPSPort, session)
+	result := new(GenericFlow).Generate(srcIP, dstIP, utils.HTTPSPort, nil)
 
-	// IPv4 fields should be populated
 	if result.SourceIPv4Addr == 0 {
 		t.Error("expected non-zero IPv4 src")
 	}
@@ -573,7 +572,6 @@ func TestGenericFlowIPv4_ZerosIPv6(t *testing.T) {
 		t.Error("expected non-zero IPv4 dst")
 	}
 
-	// IPv6 fields should be zeroed
 	if result.SourceIPv6Addr != [16]byte{} {
 		t.Errorf("expected zeroed IPv6 src, got %v", result.SourceIPv6Addr)
 	}
@@ -592,8 +590,8 @@ func TestGenerateDataIPFIX_IPv6(t *testing.T) {
 	t.Parallel()
 	flowCount := 10
 	sourceID := 618
-	session := netflow.NewSession()
-	flow, err := GenerateDataIPFIX(flowCount, sourceID, "2001:db8::/32", "2001:db8::/32", utils.HTTPSPort, session)
+	seq := NewIPFIXSequence()
+	flow, err := GenerateDataIPFIX(flowCount, sourceID, "2001:db8::/32", "2001:db8::/32", utils.HTTPSPort, seq)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -610,20 +608,17 @@ func TestGenerateDataIPFIX_IPv6(t *testing.T) {
 			t.Errorf("Items count wrong! Got: %d Want: %d", len(dFlow.Items), flowCount)
 		}
 
-		// Verify each item has IPv6 addresses populated
 		for i, item := range dFlow.Items {
 			gf, ok := item.(GenericFlow)
 			if !ok {
 				t.Fatalf("Item %d is not a GenericFlow", i)
 			}
-			// IPv6 addresses should be populated (non-zero)
 			if gf.SourceIPv6Addr == [16]byte{} {
 				t.Errorf("Item %d: expected non-zero IPv6 src", i)
 			}
 			if gf.DestIPv6Addr == [16]byte{} {
 				t.Errorf("Item %d: expected non-zero IPv6 dst", i)
 			}
-			// IPv4 addresses should be zeroed
 			if gf.SourceIPv4Addr != 0 {
 				t.Errorf("Item %d: expected zeroed IPv4 src, got %d", i, gf.SourceIPv4Addr)
 			}
@@ -638,8 +633,8 @@ func TestGenerateIPFIX_IPv6(t *testing.T) {
 	t.Parallel()
 	flowCount := 10
 	sourceID := 618
-	session := netflow.NewSession()
-	flow, err := GenerateIPFIX(flowCount, sourceID, "2001:db8::/32", "2001:db8::/32", session)
+	seq := NewIPFIXSequence()
+	flow, err := GenerateIPFIX(flowCount, sourceID, "2001:db8::/32", "2001:db8::/32", seq)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -653,24 +648,20 @@ func TestGenerateIPFIX_IPv6(t *testing.T) {
 	if len(flow.DataFlowSets) < 1 {
 		t.Error("Should have data flowsets")
 	}
-	if flow.Header.FlowCount != uint16(flowCount+1) {
-		t.Errorf("FlowCount wrong! Got: %d Want: %d", flow.Header.FlowCount, flowCount+1)
-	}
 }
 
 func TestToBytes_IPv6_RoundTrip(t *testing.T) {
 	t.Parallel()
 	sourceID := 618
 	flowCount := 10
-	session := netflow.NewSession()
+	seq := NewIPFIXSequence()
 
-	dFlow, err := GenerateDataIPFIX(flowCount, sourceID, "2001:db8::/32", "2001:db8::/32", utils.HTTPSPort, session)
+	dFlow, err := GenerateDataIPFIX(flowCount, sourceID, "2001:db8::/32", "2001:db8::/32", utils.HTTPSPort, seq)
 	if err != nil {
 		t.Fatal(err)
 	}
-	dBuf := dFlow.ToBytes()
+	dBuf, _ := dFlow.ToBytes()
 
-	// Read back
 	dLength := dBuf.Len()
 	dread := make([]byte, dLength)
 	dn, err := dBuf.Read(dread)
@@ -681,7 +672,6 @@ func TestToBytes_IPv6_RoundTrip(t *testing.T) {
 		t.Fatalf("Returned invalid IPFIX Data buffer length! Got: %d Want: %d", dn, dBuf.Len())
 	}
 
-	// Parse Data — skip the IPFIX header first
 	dreader := bytes.NewReader(dread)
 	var parsedHeader Header
 	if err := binary.Read(dreader, binary.BigEndian, &parsedHeader); err != nil {
@@ -702,7 +692,6 @@ func TestToBytes_IPv6_RoundTrip(t *testing.T) {
 		if err := binary.Read(dreader, binary.BigEndian, &dataItem); err != nil {
 			t.Fatalf("Issue reading IPFIX GenericFlow: %v", err)
 		}
-		// Verify IPv6 addresses survived serialization
 		if dataItem.SourceIPv6Addr == [16]byte{} {
 			t.Errorf("Item %d: IPv6 src was zeroed after serialization", i)
 		}
@@ -730,29 +719,29 @@ func TestToBytes_IPv6_BufferLengthMatchesFlowSetLengths(t *testing.T) {
 	t.Parallel()
 	sourceID := 618
 	flowCount := 10
-	session := netflow.NewSession()
+	seq := NewIPFIXSequence()
 
-	dFlow, err := GenerateDataIPFIX(flowCount, sourceID, "2001:db8::/32", "2001:db8::/32", utils.HTTPSPort, session)
+	dFlow, err := GenerateDataIPFIX(flowCount, sourceID, "2001:db8::/32", "2001:db8::/32", utils.HTTPSPort, seq)
 	if err != nil {
 		t.Fatal(err)
 	}
-	dBuf := dFlow.ToBytes()
-	expectedDLen := binary.Size(dFlow.Header)
+	dBuf, _ := dFlow.ToBytes()
+	expectedDLen := 16
 	for _, fs := range dFlow.DataFlowSets {
 		expectedDLen += int(fs.Length)
 	}
 	if dBuf.Len() != expectedDLen {
 		t.Errorf("IPv6 Data buffer length mismatch: got %d, want %d (header %d + flowsets %d)",
-			dBuf.Len(), expectedDLen, binary.Size(dFlow.Header),
-			expectedDLen-binary.Size(dFlow.Header))
+			dBuf.Len(), expectedDLen, 16,
+			expectedDLen-16)
 	}
 
-	cFlow, err := GenerateIPFIX(flowCount, sourceID, "2001:db8::/32", "2001:db8::/32", session)
+	cFlow, err := GenerateIPFIX(flowCount, sourceID, "2001:db8::/32", "2001:db8::/32", seq)
 	if err != nil {
 		t.Fatal(err)
 	}
-	cBuf := cFlow.ToBytes()
-	expectedCLen := binary.Size(cFlow.Header)
+	cBuf, _ := cFlow.ToBytes()
+	expectedCLen := 16
 	for _, fs := range cFlow.TemplateFlowSets {
 		expectedCLen += int(fs.Length)
 	}
@@ -762,5 +751,376 @@ func TestToBytes_IPv6_BufferLengthMatchesFlowSetLengths(t *testing.T) {
 	if cBuf.Len() != expectedCLen {
 		t.Errorf("IPv6 Combined buffer length mismatch: got %d, want %d",
 			cBuf.Len(), expectedCLen)
+	}
+}
+
+func TestHeader_Length_SetCorrectly(t *testing.T) {
+	t.Parallel()
+	seq := NewIPFIXSequence()
+	flow, err := GenerateDataIPFIX(5, 42, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, seq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	buf, _ := flow.ToBytes()
+	payload := buf.Bytes()
+
+	declaredLength := binary.BigEndian.Uint16(payload[2:4])
+	if int(declaredLength) != len(payload) {
+		t.Errorf("Header Length %d does not match payload length %d", declaredLength, len(payload))
+	}
+}
+
+func TestSequenceNumber_OnlyDataRecords(t *testing.T) {
+	t.Parallel()
+	seq := NewIPFIXSequence()
+
+	// Template-only messages should have sequence number 0
+	tpl := GenerateTemplateIPFIX(42, seq)
+	if tpl.Header.SequenceNumber != 0 {
+		t.Errorf("Template-only message should have sequence 0, got %d", tpl.Header.SequenceNumber)
+	}
+
+	// Data messages should have increasing sequence numbers
+	d1, err := GenerateDataIPFIX(1, 42, "10.0.0.0/8", "10.0.0.0/8", 443, seq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// d1 uses seq 1 and advances seq by 1 (1 record)
+
+	d2, err := GenerateDataIPFIX(3, 42, "10.0.0.0/8", "10.0.0.0/8", 443, seq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// d2 uses seq 2 and advances seq by 3 (3 records)
+
+	// d2 should be 1 ahead of d1 (seq was at 2 when d2 was created)
+	if d2.Header.SequenceNumber != d1.Header.SequenceNumber+1 {
+		t.Errorf("Expected sequence to advance by 1, got d1=%d, d2=%d",
+			d1.Header.SequenceNumber, d2.Header.SequenceNumber)
+	}
+
+	// After d1 (1 record) and d2 (3 records), seq counter should be at 4
+	// Reserve(1) should return 4 and advance to 5
+	nextSeq := seq.Reserve(1)
+	if nextSeq != 4 {
+		t.Errorf("Expected next sequence to be 4, got %d", nextSeq)
+	}
+}
+
+func TestHeader_16Bytes(t *testing.T) {
+	t.Parallel()
+	h := Header{
+		Version:             10,
+		Length:              100,
+		ExportTime:          1234567890,
+		SequenceNumber:      42,
+		ObservationDomainId: 618,
+	}
+	buf := new(bytes.Buffer)
+	binary.Write(buf, binary.BigEndian, h)
+	if buf.Len() != 16 {
+		t.Errorf("Header serializes to %d bytes, expected 16", buf.Len())
+	}
+}
+
+// Golden wire-format fixture tests verify exact byte layouts against RFC 7011.
+
+func TestGolden_HeaderOnlyMessage(t *testing.T) {
+	t.Parallel()
+	// RFC 7011 permits a 16-byte header-only message (zero Sets).
+	payload := make([]byte, 16)
+	binary.BigEndian.PutUint16(payload[0:2], 10)   // Version
+	binary.BigEndian.PutUint16(payload[2:4], 16)   // Length
+	binary.BigEndian.PutUint32(payload[4:8], 1000) // ExportTime
+	binary.BigEndian.PutUint32(payload[8:12], 0)   // SequenceNumber
+	binary.BigEndian.PutUint32(payload[12:16], 42) // ObservationDomainId
+
+	ok, err := IsValidIPFIX(payload)
+	if err != nil {
+		t.Fatalf("IsValidIPFIX error: %v", err)
+	}
+	if !ok {
+		t.Error("IsValidIPFIX should accept header-only message")
+	}
+}
+
+func TestGolden_TemplateWithdrawal(t *testing.T) {
+	t.Parallel()
+	// RFC 7011 §8.1: Template withdrawal is a Template Record with
+	// Field Count of 0. The Set contains only the FlowSet header (4 bytes)
+	// plus the withdrawal record (4 bytes = TemplateID + FieldCount).
+	payload := make([]byte, 24)
+	// Header
+	binary.BigEndian.PutUint16(payload[0:2], 10)   // Version
+	binary.BigEndian.PutUint16(payload[2:4], 24)   // Length
+	binary.BigEndian.PutUint32(payload[4:8], 1000) // ExportTime
+	binary.BigEndian.PutUint32(payload[8:12], 0)   // SequenceNumber
+	binary.BigEndian.PutUint32(payload[12:16], 42) // ObservationDomainId
+	// Template Set (Set ID = 2, Length = 8)
+	binary.BigEndian.PutUint16(payload[16:18], 2) // FlowSetID
+	binary.BigEndian.PutUint16(payload[18:20], 8) // Set Length
+	// Template withdrawal record
+	binary.BigEndian.PutUint16(payload[20:22], 256) // TemplateID
+	binary.BigEndian.PutUint16(payload[22:24], 0)   // FieldCount (0 = withdrawal)
+
+	ok, err := IsValidIPFIX(payload)
+	if err != nil {
+		t.Fatalf("IsValidIPFIX error: %v", err)
+	}
+	if !ok {
+		t.Error("IsValidIPFIX should accept template withdrawal")
+	}
+}
+
+func TestGolden_OptionsTemplateWithdrawal(t *testing.T) {
+	t.Parallel()
+	// RFC 7011 §8.1: Options Template withdrawal is 4 bytes:
+	// TemplateID(2) + FieldCount(2, value 0). No Scope Field Count field.
+	// Set = FlowSet header(4) + withdrawal record(4) = 8 bytes.
+	// Message = Header(16) + Set(8) = 24 bytes.
+	payload := make([]byte, 24)
+	// Header
+	binary.BigEndian.PutUint16(payload[0:2], 10)   // Version
+	binary.BigEndian.PutUint16(payload[2:4], 24)   // Length
+	binary.BigEndian.PutUint32(payload[4:8], 1000) // ExportTime
+	binary.BigEndian.PutUint32(payload[8:12], 0)   // SequenceNumber
+	binary.BigEndian.PutUint32(payload[12:16], 42) // ObservationDomainId
+	// Options Template Set (Set ID = 3, Length = 8)
+	binary.BigEndian.PutUint16(payload[16:18], 3) // FlowSetID
+	binary.BigEndian.PutUint16(payload[18:20], 8) // Set Length
+	// Options Template withdrawal record (4 bytes, RFC 7011 §8.1)
+	binary.BigEndian.PutUint16(payload[20:22], 257) // TemplateID
+	binary.BigEndian.PutUint16(payload[22:24], 0)   // FieldCount (0 = withdrawal)
+
+	ok, err := IsValidIPFIX(payload)
+	if err != nil {
+		t.Fatalf("IsValidIPFIX error: %v", err)
+	}
+	if !ok {
+		t.Error("IsValidIPFIX should accept options template withdrawal")
+	}
+}
+
+func TestGolden_RejectOptionsTemplateZeroScopeFields(t *testing.T) {
+	t.Parallel()
+	// RFC 7011 §3.4.2.2: Normal Options Templates must have at least one
+	// scope field (Scope Field Count >= 1). Only withdrawals have Field Count 0.
+	// Layout: Header(16) + SetHeader(4) + TemplateID(2) + FieldCount(2) +
+	//         ScopeFieldCount(2) + fieldSpecifier(4) + padding(2) = 32 bytes.
+	payload := make([]byte, 32)
+	binary.BigEndian.PutUint16(payload[0:2], 10)   // Version
+	binary.BigEndian.PutUint16(payload[2:4], 32)   // Length
+	binary.BigEndian.PutUint32(payload[4:8], 1000) // ExportTime
+	binary.BigEndian.PutUint32(payload[8:12], 0)   // SequenceNumber
+	binary.BigEndian.PutUint32(payload[12:16], 42) // ObservationDomainId
+	// Options Template Set (Set ID = 3, Length = 16)
+	binary.BigEndian.PutUint16(payload[16:18], 3)  // FlowSetID
+	binary.BigEndian.PutUint16(payload[18:20], 16) // Set Length
+	// Options Template record with Scope Field Count = 0 (invalid)
+	binary.BigEndian.PutUint16(payload[20:22], 257) // TemplateID
+	binary.BigEndian.PutUint16(payload[22:24], 1)   // FieldCount (1, not withdrawal)
+	binary.BigEndian.PutUint16(payload[24:26], 0)   // ScopeFieldCount (0 = invalid)
+	binary.BigEndian.PutUint16(payload[26:28], 149) // ElementID
+	binary.BigEndian.PutUint16(payload[28:30], 4)   // Length
+	// Padding (2 bytes)
+
+	ok, err := IsValidIPFIX(payload)
+	if ok {
+		t.Error("IsValidIPFIX should reject Options Template with Scope Field Count 0")
+	}
+	if err == nil {
+		t.Error("IsValidIPFIX should return error for Scope Field Count 0")
+	}
+}
+
+func TestGolden_TemplateSetByteLayout(t *testing.T) {
+	t.Parallel()
+	// Verify exact byte layout of a Template Set with one 2-field template.
+	// Fields: octetDeltaCount(1, len=4), packetDeltaCount(2, len=4).
+	// Record: TemplateID(2) + FieldCount(2) + 2*FieldSpecifier(4) = 12 bytes.
+	// Set: FlowSetID(2) + Length(2) + record(12) = 16 bytes.
+	// Message: Header(16) + Set(16) = 32 bytes.
+	payload := make([]byte, 32)
+	// Header
+	binary.BigEndian.PutUint16(payload[0:2], 10)   // Version
+	binary.BigEndian.PutUint16(payload[2:4], 32)   // Length
+	binary.BigEndian.PutUint32(payload[4:8], 1000) // ExportTime
+	binary.BigEndian.PutUint32(payload[8:12], 0)   // SequenceNumber
+	binary.BigEndian.PutUint32(payload[12:16], 42) // ObservationDomainId
+	// Template Set
+	binary.BigEndian.PutUint16(payload[16:18], 2)  // FlowSetID
+	binary.BigEndian.PutUint16(payload[18:20], 16) // Set Length
+	// Template record
+	binary.BigEndian.PutUint16(payload[20:22], 256) // TemplateID
+	binary.BigEndian.PutUint16(payload[22:24], 2)   // FieldCount
+	// Field 1: octetDeltaCount
+	binary.BigEndian.PutUint16(payload[24:26], 1) // ElementID
+	binary.BigEndian.PutUint16(payload[26:28], 4) // Length
+	// Field 2: packetDeltaCount
+	binary.BigEndian.PutUint16(payload[28:30], 2) // ElementID
+	binary.BigEndian.PutUint16(payload[30:32], 4) // Length
+
+	ok, err := IsValidIPFIX(payload)
+	if err != nil {
+		t.Fatalf("IsValidIPFIX error: %v", err)
+	}
+	if !ok {
+		t.Error("IsValidIPFIX should accept valid template set")
+	}
+}
+
+func TestGolden_DataSetByteLayout(t *testing.T) {
+	t.Parallel()
+	// Verify exact byte layout of a Data Set with one record.
+	// Template 256 defines: octetDeltaCount(4) + packetDeltaCount(4) = 8 bytes.
+	// Set: FlowSetID(2) + Length(2) + record(8) = 12 bytes.
+	// Message: Header(16) + Set(12) = 28 bytes.
+	payload := make([]byte, 28)
+	// Header
+	binary.BigEndian.PutUint16(payload[0:2], 10)   // Version
+	binary.BigEndian.PutUint16(payload[2:4], 28)   // Length
+	binary.BigEndian.PutUint32(payload[4:8], 1000) // ExportTime
+	binary.BigEndian.PutUint32(payload[8:12], 5)   // SequenceNumber
+	binary.BigEndian.PutUint32(payload[12:16], 42) // ObservationDomainId
+	// Data Set (ID = TemplateID = 256, Length = 12)
+	binary.BigEndian.PutUint16(payload[16:18], 256) // FlowSetID
+	binary.BigEndian.PutUint16(payload[18:20], 12)  // Set Length
+	// Data record: octetDeltaCount(4) + packetDeltaCount(4)
+	binary.BigEndian.PutUint32(payload[20:24], 1000) // octetDeltaCount
+	binary.BigEndian.PutUint32(payload[24:28], 10)   // packetDeltaCount
+
+	ok, err := IsValidIPFIX(payload)
+	if err != nil {
+		t.Fatalf("IsValidIPFIX error: %v", err)
+	}
+	if !ok {
+		t.Error("IsValidIPFIX should accept valid data set")
+	}
+}
+
+func TestGolden_RejectReservedSetID(t *testing.T) {
+	t.Parallel()
+	payload := make([]byte, 20)
+	binary.BigEndian.PutUint16(payload[0:2], 10)   // Version
+	binary.BigEndian.PutUint16(payload[2:4], 20)   // Length
+	binary.BigEndian.PutUint32(payload[4:8], 1000) // ExportTime
+	binary.BigEndian.PutUint32(payload[8:12], 0)   // SequenceNumber
+	binary.BigEndian.PutUint32(payload[12:16], 42) // ObservationDomainId
+	// Set ID 0 (reserved)
+	binary.BigEndian.PutUint16(payload[16:18], 0) // FlowSetID
+	binary.BigEndian.PutUint16(payload[18:20], 4) // Set Length
+
+	ok, err := IsValidIPFIX(payload)
+	if ok {
+		t.Error("IsValidIPFIX should reject reserved Set ID 0")
+	}
+	if err == nil {
+		t.Error("IsValidIPFIX should return error for reserved Set ID 0")
+	}
+}
+
+func TestGolden_RejectUnassignedSetID(t *testing.T) {
+	t.Parallel()
+	payload := make([]byte, 20)
+	binary.BigEndian.PutUint16(payload[0:2], 10)   // Version
+	binary.BigEndian.PutUint16(payload[2:4], 20)   // Length
+	binary.BigEndian.PutUint32(payload[4:8], 1000) // ExportTime
+	binary.BigEndian.PutUint32(payload[8:12], 0)   // SequenceNumber
+	binary.BigEndian.PutUint32(payload[12:16], 42) // ObservationDomainId
+	// Set ID 100 (unassigned, range 4-255)
+	binary.BigEndian.PutUint16(payload[16:18], 100) // FlowSetID
+	binary.BigEndian.PutUint16(payload[18:20], 4)   // Set Length
+
+	ok, err := IsValidIPFIX(payload)
+	if ok {
+		t.Error("IsValidIPFIX should reject unassigned Set ID 100")
+	}
+	if err == nil {
+		t.Error("IsValidIPFIX should return error for unassigned Set ID 100")
+	}
+}
+
+func TestGolden_RejectMismatchedMessageLength(t *testing.T) {
+	t.Parallel()
+	// Header says 20 bytes but payload is only 16.
+	payload := make([]byte, 16)
+	binary.BigEndian.PutUint16(payload[0:2], 10)   // Version
+	binary.BigEndian.PutUint16(payload[2:4], 20)   // Length (wrong)
+	binary.BigEndian.PutUint32(payload[4:8], 1000) // ExportTime
+	binary.BigEndian.PutUint32(payload[8:12], 0)   // SequenceNumber
+	binary.BigEndian.PutUint32(payload[12:16], 42) // ObservationDomainId
+
+	ok, err := IsValidIPFIX(payload)
+	if ok {
+		t.Error("IsValidIPFIX should reject mismatched message length")
+	}
+	if err == nil {
+		t.Error("IsValidIPFIX should return error for mismatched message length")
+	}
+}
+
+func TestOversizedPacket_NoSequenceConsumed(t *testing.T) {
+	t.Parallel()
+	// A DataFlowSet that exceeds 65535 bytes must fail during Generate,
+	// before any sequence numbers are reserved.
+	seq := NewIPFIXSequence()
+
+	// GenericFlow is 76 bytes. 790 records * 76 = 60040 + 4 header = 60044.
+	// But with the full record size, we need to exceed 65535.
+	// 65535 - 16(header) = 65519 available for sets.
+	// 65519 - 4(set header) = 65515 for records.
+	// 65515 / 76 = 862 records max. So 863+ records should overflow.
+	// Use a large number to guarantee overflow.
+	flow, err := GenerateDataIPFIX(1000, 42, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, seq)
+	if err == nil {
+		t.Fatal("Expected error for oversized packet, got nil")
+	}
+
+	// Sequence counter must not have advanced
+	if seq.Current() != 0 {
+		t.Errorf("Sequence counter advanced to %d despite oversized packet failure", seq.Current())
+	}
+	_ = flow
+}
+
+func TestTemplateRetransmission_SameSequenceNumber(t *testing.T) {
+	t.Parallel()
+	// Template-only messages must not advance the sequence number.
+	seq := NewIPFIXSequence()
+
+	t1 := GenerateTemplateIPFIX(42, seq)
+	t2 := GenerateTemplateIPFIX(42, seq)
+	t3 := GenerateTemplateIPFIX(42, seq)
+
+	if t1.Header.SequenceNumber != 0 {
+		t.Errorf("t1 sequence should be 0, got %d", t1.Header.SequenceNumber)
+	}
+	if t2.Header.SequenceNumber != 0 {
+		t.Errorf("t2 sequence should be 0, got %d", t2.Header.SequenceNumber)
+	}
+	if t3.Header.SequenceNumber != 0 {
+		t.Errorf("t3 sequence should be 0, got %d", t3.Header.SequenceNumber)
+	}
+	if seq.Current() != 0 {
+		t.Errorf("Sequence counter should be 0 after template messages, got %d", seq.Current())
+	}
+}
+
+func TestOptionsDataRecord_AdvancesSequence(t *testing.T) {
+	t.Parallel()
+	// Options Data Records are Data Records and must advance the sequence number.
+	seq := NewIPFIXSequence()
+
+	od1 := GenerateOptionsDataIPFIX(42, seq)
+	od2 := GenerateOptionsDataIPFIX(42, seq)
+
+	if od1.Header.SequenceNumber != 0 {
+		t.Errorf("od1 sequence should be 0, got %d", od1.Header.SequenceNumber)
+	}
+	if od2.Header.SequenceNumber != 1 {
+		t.Errorf("od2 sequence should be 1, got %d", od2.Header.SequenceNumber)
+	}
+	if seq.Current() != 2 {
+		t.Errorf("Sequence counter should be 2 after 2 options data records, got %d", seq.Current())
 	}
 }

--- a/ipfix/profile_generic.go
+++ b/ipfix/profile_generic.go
@@ -30,10 +30,10 @@ func (p *GenericIPFIXProfile) Name() string {
 // TemplateFields returns the 19-field IPFIX template that matches GenericFlow struct layout.
 func (p *GenericIPFIXProfile) TemplateFields() []Field {
 	return []Field{
-		{Type: InOctets, Length: 4},
-		{Type: OutOctets, Length: 4},
-		{Type: InPackets, Length: 4},
-		{Type: OutPackets, Length: 4},
+		{Type: OctetDeltaCount, Length: 4},
+		{Type: PostOctetDeltaCount, Length: 4},
+		{Type: PacketDeltaCount, Length: 4},
+		{Type: PostPacketDeltaCount, Length: 4},
 		{Type: SourceIPv4Address, Length: 4},
 		{Type: DestinationIPv4Address, Length: 4},
 		{Type: SourceIPv6Address, Length: 16},
@@ -44,8 +44,8 @@ func (p *GenericIPFIXProfile) TemplateFields() []Field {
 		{Type: DestinationTransportPort, Length: 2},
 		{Type: ProtocolIdentifier, Length: 1},
 		{Type: TCPFlags, Length: 1},
-		{Type: FlowStartMilliseconds, Length: 4},
-		{Type: FlowEndMilliseconds, Length: 4},
+		{Type: FlowStartMilliseconds, Length: 8},
+		{Type: FlowEndMilliseconds, Length: 8},
 		{Type: FlowDirection, Length: 1},
 		{Type: IPClassOfService, Length: 1},
 		{Type: FlowEndReason, Length: 1},
@@ -61,8 +61,8 @@ func (p *MinimalIPFIXProfile) Name() string { return "minimal" }
 // TemplateFields returns the 7-field minimal IPFIX template.
 func (p *MinimalIPFIXProfile) TemplateFields() []Field {
 	return []Field{
-		{Type: InOctets, Length: 4},
-		{Type: InPackets, Length: 4},
+		{Type: OctetDeltaCount, Length: 4},
+		{Type: PacketDeltaCount, Length: 4},
 		{Type: SourceIPv4Address, Length: 4},
 		{Type: DestinationIPv4Address, Length: 4},
 		{Type: SourceTransportPort, Length: 2},
@@ -73,8 +73,8 @@ func (p *MinimalIPFIXProfile) TemplateFields() []Field {
 
 // MinimalIPFIXFlow is a minimal IPFIX flow record with 7 essential fields.
 type MinimalIPFIXFlow struct {
-	InOctets           uint32
-	InPackets          uint32
+	OctetDeltaCount    uint32
+	PacketDeltaCount   uint32
 	SourceIPv4Addr     uint32
 	DestIPv4Addr       uint32
 	SourcePort         uint16
@@ -84,8 +84,8 @@ type MinimalIPFIXFlow struct {
 
 // Generate creates a MinimalIPFIXFlow with randomly generated data.
 func (mf *MinimalIPFIXFlow) Generate(srcIP net.IP, dstIP net.IP, flowSrcPort int, session *netflow.Session) MinimalIPFIXFlow {
-	mf.InOctets = utils.GenerateRand32(10000)
-	mf.InPackets = utils.GenerateRand32(10000)
+	mf.OctetDeltaCount = utils.GenerateRand32(10000)
+	mf.PacketDeltaCount = utils.GenerateRand32(10000)
 
 	if srcIP.To4() != nil {
 		mf.SourceIPv4Addr = utils.IPToNum(srcIP)
@@ -131,18 +131,18 @@ func (p *ExtendedIPFIXProfile) Name() string { return "extended" }
 // TemplateFields returns the extended IPFIX template with additional fields.
 func (p *ExtendedIPFIXProfile) TemplateFields() []Field {
 	return []Field{
-		{Type: InOctets, Length: 4},
-		{Type: OutOctets, Length: 4},
-		{Type: InPackets, Length: 4},
-		{Type: OutPackets, Length: 4},
+		{Type: OctetDeltaCount, Length: 4},
+		{Type: PostOctetDeltaCount, Length: 4},
+		{Type: PacketDeltaCount, Length: 4},
+		{Type: PostPacketDeltaCount, Length: 4},
 		{Type: SourceIPv4Address, Length: 4},
 		{Type: DestinationIPv4Address, Length: 4},
 		{Type: SourceTransportPort, Length: 2},
 		{Type: DestinationTransportPort, Length: 2},
 		{Type: ProtocolIdentifier, Length: 1},
 		{Type: TCPFlags, Length: 1},
-		{Type: FlowStartMilliseconds, Length: 4},
-		{Type: FlowEndMilliseconds, Length: 4},
+		{Type: FlowStartMilliseconds, Length: 8},
+		{Type: FlowEndMilliseconds, Length: 8},
 		{Type: FlowDirection, Length: 1},
 		{Type: IPClassOfService, Length: 1},
 		{Type: FlowEndReason, Length: 1},


### PR DESCRIPTION
## Summary

Complete IPFIX RFC 7011 conformance fix addressing all 9 issues identified in ISSUES.md plus additional findings from post-merge review.

## Changes

### Header & Format
- Replace NetFlow v9 20-byte header with RFC 7011 16-byte format
- Fields: Version, Length, ExportTime, SequenceNumber, ObservationDomainId
- ToBytes calculates and writes correct total message Length
- Returns error and rejects messages exceeding 65535 bytes

### Set IDs
- Template Sets: ID 2 (was 0)
- Options Template Sets: ID 3 (was 0)

### Information Element Identifiers
- All IE IDs corrected to IANA-registered values
- octetDeltaCount=1, packetDeltaCount=2, postOctetDeltaCount=23, postPacketDeltaCount=24
- IPv6 addresses: 27/28 (were 25/26)
- flowDirection=61 (was 1024), flowEndReason=136 (was 157)
- observationDomainId=149 (was 31)

### Options Template Record Layout
- RFC 7011 Section 3.4.2.2: TemplateID, FieldCount, ScopeFieldCount, then field specifiers
- Removed nonstandard Data Field Count

### Timestamps
- flowStartMilliseconds/flowEndMilliseconds: uint64 epoch milliseconds (were uint32 relative)
- Template length 8 bytes (was 4)

### Sequence Numbers
- Count Data Records only; Template/Options Template Records do not advance
- IPFIXSequence provides atomic sequence range reservation for concurrent use
- DataFlowSet.Generate validates full-width length before uint16 conversion

### Validation
- IsValidIPFIX accepts header-only messages (16 bytes, zero Sets) per RFC 7011
- Template/Options Template Withdrawals accepted (Field Count 0, 4 bytes) per Section 8.1
- Normal Options Templates reject scopeFieldCount == 0 per Section 3.4.2.2
- Rejects reserved Set IDs (0, 1) and unassigned range (4-255)
- Golden wire-format fixture tests provide transport-independent validation

## Testing
- All existing tests pass with race detector
- 13 new golden fixture tests verify exact byte layouts
- Behavioral tests for sequence number semantics and overflow protection