### PR TITLE
Fix: F-08 NetFlow v9 validation - Options Template parsing, FlowCount accuracy, and padding ambiguity

### DIFF
--- a/netflow/coverage_test.go
+++ b/netflow/coverage_test.go
@@ -502,3 +502,658 @@ func TestField_String_Output(t *testing.T) {
 		t.Error("Field String should contain length")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Options Template FlowSet validation (RFC 3954 Section 6.1)
+// ---------------------------------------------------------------------------
+
+// buildOptionsTemplatePacket builds a minimal NetFlow v9 packet containing
+// a Template FlowSet (ID=0) and an Options Template FlowSet (ID=1).
+func buildOptionsTemplatePacket() []byte {
+	var buf bytes.Buffer
+
+	// Header: version=9, flowCount=2 (1 template + 1 options template)
+	binary.Write(&buf, binary.BigEndian, uint16(9))
+	binary.Write(&buf, binary.BigEndian, uint16(2))
+	binary.Write(&buf, binary.BigEndian, uint32(1000))    // SysUptime
+	binary.Write(&buf, binary.BigEndian, uint32(1000000)) // UnixSec
+	binary.Write(&buf, binary.BigEndian, uint32(1))       // FlowSequence
+	binary.Write(&buf, binary.BigEndian, uint32(618))     // SourceID
+
+	// Template FlowSet (ID=0)
+	// One template: ID=256, 2 fields (each 4 bytes = Type+Length)
+	// Fields: (type=1, len=4), (type=2, len=4)
+	// Total: FlowSet header(4) + tmplID(2) + fieldCount(2) + 2*fieldSpec(4) = 16
+	tmplLen := uint16(4 + 2 + 2 + 2*4)                // = 16
+	binary.Write(&buf, binary.BigEndian, uint16(0))   // FlowSetID
+	binary.Write(&buf, binary.BigEndian, tmplLen)     // Length
+	binary.Write(&buf, binary.BigEndian, uint16(256)) // TemplateID
+	binary.Write(&buf, binary.BigEndian, uint16(2))   // FieldCount
+	binary.Write(&buf, binary.BigEndian, uint16(1))   // Field 1 Type
+	binary.Write(&buf, binary.BigEndian, uint16(4))   // Field 1 Length
+	binary.Write(&buf, binary.BigEndian, uint16(2))   // Field 2 Type
+	binary.Write(&buf, binary.BigEndian, uint16(4))   // Field 2 Length
+
+	// Options Template FlowSet (ID=1) - RFC 3954 Section 6.1
+	// One options template: ID=257, scopeLen=8 (2 scope fields), optLen=8 (2 option fields)
+	// 6-byte header + 8 bytes scope field specifiers + 8 bytes option field specifiers
+	// Total: FlowSet header(4) + header(6) + scope(8) + options(8) = 26
+	optsLen := uint16(4 + 6 + 8 + 8)                  // = 26
+	binary.Write(&buf, binary.BigEndian, uint16(1))   // FlowSetID
+	binary.Write(&buf, binary.BigEndian, optsLen)     // Length
+	binary.Write(&buf, binary.BigEndian, uint16(257)) // TemplateID
+	binary.Write(&buf, binary.BigEndian, uint16(8))   // Option Scope Length (bytes)
+	binary.Write(&buf, binary.BigEndian, uint16(8))   // Option Length (bytes)
+	// Scope field specifiers (2 fields, each 4 bytes)
+	binary.Write(&buf, binary.BigEndian, uint16(1)) // Scope field 1 Type
+	binary.Write(&buf, binary.BigEndian, uint16(4)) // Scope field 1 Length
+	binary.Write(&buf, binary.BigEndian, uint16(2)) // Scope field 2 Type
+	binary.Write(&buf, binary.BigEndian, uint16(4)) // Scope field 2 Length
+	// Option field specifiers (2 fields, each 4 bytes)
+	binary.Write(&buf, binary.BigEndian, uint16(3)) // Option field 1 Type
+	binary.Write(&buf, binary.BigEndian, uint16(4)) // Option field 1 Length
+	binary.Write(&buf, binary.BigEndian, uint16(4)) // Option field 2 Type
+	binary.Write(&buf, binary.BigEndian, uint16(4)) // Option field 2 Length
+
+	return buf.Bytes()
+}
+
+func TestIsValidNetFlow_OptionsTemplate_Valid(t *testing.T) {
+	t.Parallel()
+	payload := buildOptionsTemplatePacket()
+
+	valid, err := IsValidNetFlow(payload, 9)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !valid {
+		t.Error("valid Options Template packet should pass validation")
+	}
+}
+
+func TestIsValidNetFlow_OptionsTemplate_BadTemplateID(t *testing.T) {
+	t.Parallel()
+	payload := buildOptionsTemplatePacket()
+	// Template FlowSet is 16 bytes, so Options Template FlowSet starts at offset 36
+	// Options Template TemplateID is at offset 36 + 4 = 40
+	// Change TemplateID from 257 to 255 (below 256)
+	payload[40] = 0
+	payload[41] = 255
+
+	valid, err := IsValidNetFlow(payload, 9)
+	if err == nil {
+		t.Error("expected error for Options Template ID below 256")
+	}
+	if valid {
+		t.Error("Options Template with ID below 256 should not be valid")
+	}
+}
+
+func TestIsValidNetFlow_OptionsTemplate_BadScopeLength(t *testing.T) {
+	t.Parallel()
+	payload := buildOptionsTemplatePacket()
+	// Option Scope Length is at offset 42 (after TemplateID at 40-41)
+	// Change from 8 to 6 (not multiple of 4)
+	binary.BigEndian.PutUint16(payload[42:44], 6)
+
+	valid, err := IsValidNetFlow(payload, 9)
+	if err == nil {
+		t.Error("expected error for Option Scope Length not multiple of 4")
+	}
+	if valid {
+		t.Error("Options Template with bad Scope Length should not be valid")
+	}
+}
+
+func TestIsValidNetFlow_OptionsTemplate_BadOptionLength(t *testing.T) {
+	t.Parallel()
+	payload := buildOptionsTemplatePacket()
+	// Option Length is at offset 44
+	// Change from 8 to 7 (not multiple of 4)
+	binary.BigEndian.PutUint16(payload[44:46], 7)
+
+	valid, err := IsValidNetFlow(payload, 9)
+	if err == nil {
+		t.Error("expected error for Option Length not multiple of 4")
+	}
+	if valid {
+		t.Error("Options Template with bad Option Length should not be valid")
+	}
+}
+
+func TestIsValidNetFlow_OptionsTemplate_ZeroFieldLength(t *testing.T) {
+	t.Parallel()
+	payload := buildOptionsTemplatePacket()
+	// First scope field length is at offset 48 (6-byte header ends at 46, first field type at 46-47, length at 48-49)
+	// Change from 4 to 0
+	binary.BigEndian.PutUint16(payload[48:50], 0)
+
+	valid, err := IsValidNetFlow(payload, 9)
+	if err == nil {
+		t.Error("expected error for zero-length scope field")
+	}
+	if valid {
+		t.Error("Options Template with zero-length field should not be valid")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Multi-record FlowCount validation
+// ---------------------------------------------------------------------------
+
+func TestIsValidNetFlow_MultiRecord_FlowCount(t *testing.T) {
+	t.Parallel()
+	// Generate packet with 10 data flows + 1 template = 11 records
+	session := NewSession()
+	nf, err := GenerateNetflow(10, 618, "10.0.0.0/8", "10.0.0.0/8", session)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	buf := nf.ToBytes()
+	payload := buf.Bytes()
+
+	valid, err := IsValidNetFlow(payload, 9)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !valid {
+		t.Error("valid multi-record NetFlow should pass validation")
+	}
+
+	// Verify header FlowCount is correct
+	var header Header
+	binary.Read(bytes.NewReader(payload), binary.BigEndian, &header)
+	if header.FlowCount != 11 {
+		t.Errorf("expected FlowCount 11 (1 template + 10 data), got %d", header.FlowCount)
+	}
+}
+
+func TestIsValidNetFlow_DataOnly_Accepted(t *testing.T) {
+	t.Parallel()
+	// GenerateDataNetflow produces data-only packets (no template)
+	session := NewSession()
+	nf, err := GenerateDataNetflow(10, 618, "10.0.0.0/8", "10.0.0.0/8", utils.HTTPSPort, session)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	buf := nf.ToBytes()
+	payload := buf.Bytes()
+
+	valid, err := IsValidNetFlow(payload, 9)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !valid {
+		t.Error("data-only NetFlow packet should pass validation (template sent in prior packet)")
+	}
+}
+
+func TestIsValidNetFlow_FlowCount_TooLow(t *testing.T) {
+	t.Parallel()
+	session := NewSession()
+	nf, err := GenerateNetflow(10, 618, "10.0.0.0/8", "10.0.0.0/8", session)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	buf := nf.ToBytes()
+	payload := buf.Bytes()
+
+	// Set FlowCount to 1 (too low for 1 template + 10 data records)
+	binary.BigEndian.PutUint16(payload[2:4], 1)
+
+	valid, err := IsValidNetFlow(payload, 9)
+	if err == nil {
+		t.Error("expected error for FlowCount less than actual records")
+	}
+	if valid {
+		t.Error("packet with FlowCount less than counted records should not be valid")
+	}
+}
+
+func TestIsValidNetFlow_FlowCount_Zero(t *testing.T) {
+	t.Parallel()
+	session := NewSession()
+	nf, err := GenerateNetflow(10, 618, "10.0.0.0/8", "10.0.0.0/8", session)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	buf := nf.ToBytes()
+	payload := buf.Bytes()
+
+	// Set FlowCount to 0
+	binary.BigEndian.PutUint16(payload[2:4], 0)
+
+	valid, err := IsValidNetFlow(payload, 9)
+	if err == nil {
+		t.Error("expected error for zero FlowCount")
+	}
+	if valid {
+		t.Error("packet with zero FlowCount should not be valid")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// countDataRecordsRange helper
+// ---------------------------------------------------------------------------
+
+func TestCountDataRecordsRange(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		dataLen int
+		recSize int
+		wantMin int
+		wantMax int
+	}{
+		{"exact_fit", 100, 10, 10, 10},
+		{"with_padding_1", 101, 10, 10, 10},
+		{"with_padding_2", 102, 10, 10, 10},
+		{"with_padding_3", 103, 10, 10, 10},
+		{"single_record", 10, 10, 1, 1},
+		{"single_record_padded", 12, 10, 1, 1},
+		{"no_valid_padding", 105, 10, -1, -1},
+		// 1-byte record: 4 data bytes can be 1 record + 3 padding or 4 records
+		{"short_record_ambiguous", 4, 1, 1, 4},
+		// 1-byte record: 3 data bytes can be 1 record + 2 padding or 3 records
+		{"short_record_ambiguous_3", 3, 1, 1, 3},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			min, max := countDataRecordsRange(tc.dataLen, tc.recSize)
+			if min != tc.wantMin || max != tc.wantMax {
+				t.Errorf("countDataRecordsRange(%d, %d) = (%d, %d), want (%d, %d)",
+					tc.dataLen, tc.recSize, min, max, tc.wantMin, tc.wantMax)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// countDataRecords helper (unambiguous only)
+// ---------------------------------------------------------------------------
+
+func TestCountDataRecords(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		dataLen   int
+		recSize   int
+		wantCount int
+	}{
+		{"exact_fit", 100, 10, 10},
+		{"with_padding_1", 101, 10, 10},
+		{"with_padding_2", 102, 10, 10},
+		{"with_padding_3", 103, 10, 10},
+		{"single_record", 10, 10, 1},
+		{"single_record_padded", 12, 10, 1},
+		{"no_valid_padding", 105, 10, -1},
+		// Ambiguous case: returns -1 (multiple valid interpretations)
+		{"short_record_ambiguous", 4, 1, -1},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := countDataRecords(tc.dataLen, tc.recSize)
+			if got != tc.wantCount {
+				t.Errorf("countDataRecords(%d, %d) = %d, want %d", tc.dataLen, tc.recSize, got, tc.wantCount)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Inflated FlowCount rejection (all templates known)
+// ---------------------------------------------------------------------------
+
+func TestIsValidNetFlow_FlowCount_Inflated_Rejected(t *testing.T) {
+	t.Parallel()
+	// Generate packet with 10 data flows + 1 template = 11 records
+	session := NewSession()
+	nf, err := GenerateNetflow(10, 618, "10.0.0.0/8", "10.0.0.0/8", session)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	buf := nf.ToBytes()
+	payload := buf.Bytes()
+
+	// Inflate FlowCount from 11 to 12
+	binary.BigEndian.PutUint16(payload[2:4], 12)
+
+	valid, err := IsValidNetFlow(payload, 9)
+	if err == nil {
+		t.Error("expected error for inflated FlowCount when all templates are known")
+	}
+	if valid {
+		t.Error("packet with FlowCount 12 but only 11 records should not be valid")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Options Template + Options Data Records: exact count
+// ---------------------------------------------------------------------------
+
+// buildOptionsDataPacket builds a NetFlow v9 packet with:
+// - Template FlowSet (ID=0): 1 template (ID=256, 2 fields, record size=8)
+// - Options Template FlowSet (ID=1): 1 options template (ID=257, 2 scope + 2 option fields, record size=16)
+// - Data FlowSet (ID=256): 3 data records (each 8 bytes)
+// - Options Data FlowSet (ID=257): 2 options data records (each 16 bytes)
+// Total records: 1 (template) + 1 (options template) + 3 (data) + 2 (options data) = 7
+func buildOptionsDataPacket() []byte {
+	var buf bytes.Buffer
+
+	// Header: version=9, flowCount=7
+	binary.Write(&buf, binary.BigEndian, uint16(9))
+	binary.Write(&buf, binary.BigEndian, uint16(7))
+	binary.Write(&buf, binary.BigEndian, uint32(1000))
+	binary.Write(&buf, binary.BigEndian, uint32(1000000))
+	binary.Write(&buf, binary.BigEndian, uint32(1))
+	binary.Write(&buf, binary.BigEndian, uint32(618))
+
+	// Template FlowSet (ID=0): 1 template, 2 fields (type=1,len=4), (type=2,len=4)
+	// Record size = 4+4 = 8
+	tmplLen := uint16(4 + 2 + 2 + 2*4) // = 16
+	binary.Write(&buf, binary.BigEndian, uint16(0))
+	binary.Write(&buf, binary.BigEndian, tmplLen)
+	binary.Write(&buf, binary.BigEndian, uint16(256)) // TemplateID
+	binary.Write(&buf, binary.BigEndian, uint16(2))   // FieldCount
+	binary.Write(&buf, binary.BigEndian, uint16(1))
+	binary.Write(&buf, binary.BigEndian, uint16(4))
+	binary.Write(&buf, binary.BigEndian, uint16(2))
+	binary.Write(&buf, binary.BigEndian, uint16(4))
+
+	// Options Template FlowSet (ID=1): 1 options template
+	// 2 scope fields (type=1,len=8), (type=2,len=8) -> record data size = 16
+	// 2 option fields (type=3,len=4), (type=4,len=4) -> included in record data size
+	// Record size = 8+8+4+4 = 24
+	scopeLen := uint16(8)                                  // 2 scope field specifiers
+	optLen := uint16(8)                                    // 2 option field specifiers
+	optsLen := uint16(4 + 6 + int(scopeLen) + int(optLen)) // = 26
+	binary.Write(&buf, binary.BigEndian, uint16(1))
+	binary.Write(&buf, binary.BigEndian, optsLen)
+	binary.Write(&buf, binary.BigEndian, uint16(257)) // Options TemplateID
+	binary.Write(&buf, binary.BigEndian, scopeLen)    // Option Scope Length
+	binary.Write(&buf, binary.BigEndian, optLen)      // Option Length
+	// Scope field specifiers
+	binary.Write(&buf, binary.BigEndian, uint16(1))
+	binary.Write(&buf, binary.BigEndian, uint16(8))
+	binary.Write(&buf, binary.BigEndian, uint16(2))
+	binary.Write(&buf, binary.BigEndian, uint16(8))
+	// Option field specifiers
+	binary.Write(&buf, binary.BigEndian, uint16(3))
+	binary.Write(&buf, binary.BigEndian, uint16(4))
+	binary.Write(&buf, binary.BigEndian, uint16(4))
+	binary.Write(&buf, binary.BigEndian, uint16(4))
+
+	// Data FlowSet (ID=256): 3 records, each 8 bytes, + padding
+	// 3 * 8 = 24 bytes, no padding needed (24 % 4 == 0)
+	dataLen := uint16(4 + 3*8) // = 28
+	binary.Write(&buf, binary.BigEndian, uint16(256))
+	binary.Write(&buf, binary.BigEndian, dataLen)
+	for range 3 {
+		binary.Write(&buf, binary.BigEndian, uint32(0x11223344))
+		binary.Write(&buf, binary.BigEndian, uint32(0x55667788))
+	}
+
+	// Options Data FlowSet (ID=257): 2 records, each 24 bytes, + padding
+	// 2 * 24 = 48 bytes, no padding needed (48 % 4 == 0)
+	optsDataLen := uint16(4 + 2*24) // = 52
+	binary.Write(&buf, binary.BigEndian, uint16(257))
+	binary.Write(&buf, binary.BigEndian, optsDataLen)
+	for range 2 {
+		// Each options data record: 8+8+4+4 = 24 bytes
+		binary.Write(&buf, binary.BigEndian, uint64(0x0011223344556677))
+		binary.Write(&buf, binary.BigEndian, uint64(0x8899AABBCCDDEEFF))
+		binary.Write(&buf, binary.BigEndian, uint32(0x11223344))
+		binary.Write(&buf, binary.BigEndian, uint32(0x55667788))
+	}
+
+	return buf.Bytes()
+}
+
+func TestIsValidNetFlow_OptionsData_ExactCount(t *testing.T) {
+	t.Parallel()
+	payload := buildOptionsDataPacket()
+
+	valid, err := IsValidNetFlow(payload, 9)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !valid {
+		t.Error("valid Options Data packet with correct FlowCount should pass validation")
+	}
+
+	// Verify the header FlowCount is exactly 7
+	var header Header
+	binary.Read(bytes.NewReader(payload), binary.BigEndian, &header)
+	if header.FlowCount != 7 {
+		t.Errorf("expected FlowCount 7, got %d", header.FlowCount)
+	}
+}
+
+func TestIsValidNetFlow_OptionsData_InflatedFlowCount_Rejected(t *testing.T) {
+	t.Parallel()
+	payload := buildOptionsDataPacket()
+
+	// Inflate FlowCount from 7 to 10
+	binary.BigEndian.PutUint16(payload[2:4], 10)
+
+	valid, err := IsValidNetFlow(payload, 9)
+	if err == nil {
+		t.Error("expected error for inflated FlowCount when all templates are known")
+	}
+	if valid {
+		t.Error("packet with FlowCount 10 but only 7 records should not be valid")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Mixed known/unknown Data FlowSets: unverifiable count accepted
+// ---------------------------------------------------------------------------
+
+func TestIsValidNetFlow_MixedTemplates_Accepted(t *testing.T) {
+	t.Parallel()
+	// Generate a packet with a template + data for template 256,
+	// then manually append a Data FlowSet for an unknown template (ID=258).
+	// The unknown template's records can't be counted, so FlowCount >= totalRecords
+	// is the only check, and an inflated FlowCount is accepted.
+	session := NewSession()
+	nf, err := GenerateNetflow(5, 618, "10.0.0.0/8", "10.0.0.0/8", session)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	buf := nf.ToBytes()
+
+	// Append a Data FlowSet for unknown template 258 (8 bytes of opaque data)
+	// Length = 4 (FlowSet header) + 8 (data) = 12
+	unknownLen := uint16(4 + 8)
+	binary.Write(&buf, binary.BigEndian, uint16(258))
+	binary.Write(&buf, binary.BigEndian, unknownLen)
+	binary.Write(&buf, binary.BigEndian, uint64(0x1122334455667788))
+
+	payload := buf.Bytes()
+
+	// Set FlowCount to 10 (1 template + 5 data + unknown records).
+	// Since template 258 is unknown, the validator can't count those records,
+	// so FlowCount >= 6 (counted) is the only requirement.
+	binary.BigEndian.PutUint16(payload[2:4], 10)
+
+	valid, err := IsValidNetFlow(payload, 9)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !valid {
+		t.Error("packet with unknown template should accept FlowCount >= counted records")
+	}
+}
+
+func TestIsValidNetFlow_MixedTemplates_FlowCountTooLow_Rejected(t *testing.T) {
+	t.Parallel()
+	session := NewSession()
+	nf, err := GenerateNetflow(5, 618, "10.0.0.0/8", "10.0.0.0/8", session)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	buf := nf.ToBytes()
+
+	// Append a Data FlowSet for unknown template 258
+	unknownLen := uint16(4 + 8)
+	binary.Write(&buf, binary.BigEndian, uint16(258))
+	binary.Write(&buf, binary.BigEndian, unknownLen)
+	binary.Write(&buf, binary.BigEndian, uint64(0x1122334455667788))
+
+	payload := buf.Bytes()
+
+	// Minimum count is 7 (1 template + 5 data + 1 unresolved FlowSet).
+	// FlowCount=6 is below the minimum.
+	binary.BigEndian.PutUint16(payload[2:4], 6)
+
+	valid, err := IsValidNetFlow(payload, 9)
+	if err == nil {
+		t.Error("expected error for FlowCount less than counted records")
+	}
+	if valid {
+		t.Error("packet with FlowCount 6 but 7+ records should not be valid")
+	}
+}
+
+func TestIsValidNetFlow_MixedTemplates_FlowCountExactMinimum_Accepted(t *testing.T) {
+	t.Parallel()
+	session := NewSession()
+	nf, err := GenerateNetflow(5, 618, "10.0.0.0/8", "10.0.0.0/8", session)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	buf := nf.ToBytes()
+
+	// Append a Data FlowSet for unknown template 258
+	unknownLen := uint16(4 + 8)
+	binary.Write(&buf, binary.BigEndian, uint16(258))
+	binary.Write(&buf, binary.BigEndian, unknownLen)
+	binary.Write(&buf, binary.BigEndian, uint64(0x1122334455667788))
+
+	payload := buf.Bytes()
+
+	// Minimum count is 7 (1 template + 5 data + 1 unresolved FlowSet).
+	// FlowCount=7 equals the minimum and should be accepted.
+	binary.BigEndian.PutUint16(payload[2:4], 7)
+
+	valid, err := IsValidNetFlow(payload, 9)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !valid {
+		t.Error("packet with FlowCount equal to minimum should be accepted")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Ambiguous short-record padding: header resolves count
+// ---------------------------------------------------------------------------
+
+// buildShortRecordPacket builds a NetFlow v9 packet with a 1-byte template
+// record and a Data FlowSet containing 4 bytes of data. With 1-byte records,
+// the 4 data bytes can be interpreted as:
+// - 1 record + 3 padding bytes (FlowCount = 2: 1 template + 1 data)
+// - 4 records + 0 padding bytes (FlowCount = 5: 1 template + 4 data)
+// Both are valid per RFC 3954. The header FlowCount resolves the ambiguity.
+func buildShortRecordPacket() []byte {
+	var buf bytes.Buffer
+
+	// Header: version=9, flowCount set below
+	binary.Write(&buf, binary.BigEndian, uint16(9))
+	binary.Write(&buf, binary.BigEndian, uint16(0)) // placeholder
+	binary.Write(&buf, binary.BigEndian, uint32(1000))
+	binary.Write(&buf, binary.BigEndian, uint32(1000000))
+	binary.Write(&buf, binary.BigEndian, uint32(1))
+	binary.Write(&buf, binary.BigEndian, uint32(618))
+
+	// Template FlowSet (ID=0): 1 template with 1 field (type=1, len=1)
+	// Record size = 1 byte
+	tmplLen := uint16(4 + 2 + 2 + 4) // FlowSet header + tmplID + fieldCount + field
+	binary.Write(&buf, binary.BigEndian, uint16(0))
+	binary.Write(&buf, binary.BigEndian, tmplLen)
+	binary.Write(&buf, binary.BigEndian, uint16(256)) // TemplateID
+	binary.Write(&buf, binary.BigEndian, uint16(1))   // FieldCount
+	binary.Write(&buf, binary.BigEndian, uint16(1))   // Field type
+	binary.Write(&buf, binary.BigEndian, uint16(1))   // Field length = 1 byte
+
+	// Data FlowSet (ID=256): 4 bytes of data
+	// With 1-byte records: could be 1 record + 3 padding or 4 records + 0 padding
+	dataLen := uint16(4 + 4) // FlowSet header + 4 data bytes
+	binary.Write(&buf, binary.BigEndian, uint16(256))
+	binary.Write(&buf, binary.BigEndian, dataLen)
+	binary.Write(&buf, binary.BigEndian, uint32(0x11223344))
+
+	return buf.Bytes()
+}
+
+func TestIsValidNetFlow_ShortRecord_Padded_FlowCount2(t *testing.T) {
+	t.Parallel()
+	payload := buildShortRecordPacket()
+	// FlowCount = 2: 1 template + 1 data record (3 padding bytes)
+	binary.BigEndian.PutUint16(payload[2:4], 2)
+
+	valid, err := IsValidNetFlow(payload, 9)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !valid {
+		t.Error("packet with FlowCount=2 (1 template + 1 padded record) should be valid")
+	}
+}
+
+func TestIsValidNetFlow_ShortRecord_Unpadded_FlowCount5(t *testing.T) {
+	t.Parallel()
+	payload := buildShortRecordPacket()
+	// FlowCount = 5: 1 template + 4 data records (0 padding bytes)
+	binary.BigEndian.PutUint16(payload[2:4], 5)
+
+	valid, err := IsValidNetFlow(payload, 9)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !valid {
+		t.Error("packet with FlowCount=5 (1 template + 4 unpadded records) should be valid")
+	}
+}
+
+func TestIsValidNetFlow_ShortRecord_OutOfRange_FlowCount1(t *testing.T) {
+	t.Parallel()
+	payload := buildShortRecordPacket()
+	// FlowCount = 1: below the minimum (2)
+	binary.BigEndian.PutUint16(payload[2:4], 1)
+
+	valid, err := IsValidNetFlow(payload, 9)
+	if err == nil {
+		t.Error("expected error for FlowCount below valid range")
+	}
+	if valid {
+		t.Error("packet with FlowCount=1 should not be valid (min is 2)")
+	}
+}
+
+func TestIsValidNetFlow_ShortRecord_OutOfRange_FlowCount6(t *testing.T) {
+	t.Parallel()
+	payload := buildShortRecordPacket()
+	// FlowCount = 6: above the maximum (5)
+	binary.BigEndian.PutUint16(payload[2:4], 6)
+
+	valid, err := IsValidNetFlow(payload, 9)
+	if err == nil {
+		t.Error("expected error for FlowCount above valid range")
+	}
+	if valid {
+		t.Error("packet with FlowCount=6 should not be valid (max is 5)")
+	}
+}

--- a/netflow/netflow.go
+++ b/netflow/netflow.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/dmabry/flowgre/utils"
@@ -35,7 +36,7 @@ func GenerateDataNetflow(flowCount int, sourceID int, srcRange string, dstRange 
 	if err != nil {
 		return Netflow{}, fmt.Errorf("generate data flow set: %w", err)
 	}
-	header := new(Header).Generate(1, sourceID, session) // always 1 for but could be more in future
+	header := new(Header).Generate(flowCount, sourceID, session)
 	netflow.Header = header
 	netflow.DataFlowSets = append(netflow.DataFlowSets, dataFlow)
 	return *netflow, nil
@@ -51,19 +52,309 @@ func GenerateTemplateNetflow(sourceID int, session *Session, profile ...FlowProf
 	return *netflow
 }
 
-// IsValidNetFlow validates that the given payload has a netflow v9 header
+// countDataRecordsRange computes the minimum and maximum possible record
+// counts for a Data FlowSet given its data length and record size.
+// The FlowSet data length includes record bytes plus 0-3 bytes of zero padding
+// to reach a 32-bit boundary (RFC 3954 §9). Padding is recommended but not
+// required (RFC 3954 §5.3), so multiple record counts may be valid.
+// Returns (minCount, maxCount) or (-1, -1) if no valid padding exists.
+func countDataRecordsRange(dataLen int, recordSize int) (int, int) {
+	minCount := -1
+	maxCount := -1
+
+	for pad := 0; pad < 4; pad++ {
+		dataBytes := dataLen - pad
+		if dataBytes > 0 && dataBytes%recordSize == 0 {
+			count := dataBytes / recordSize
+			if minCount < 0 || count < minCount {
+				minCount = count
+			}
+			if maxCount < 0 || count > maxCount {
+				maxCount = count
+			}
+		}
+	}
+
+	return minCount, maxCount
+}
+
+// countDataRecords returns the single record count when padding is unambiguous,
+// or -1 when multiple interpretations exist. Deprecated: prefer countDataRecordsRange.
+func countDataRecords(dataLen int, recordSize int) int {
+	min, max := countDataRecordsRange(dataLen, recordSize)
+	if min == max {
+		return min
+	}
+	return -1
+}
+
+// IsValidNetFlow validates the given payload as a structurally correct NetFlow v9 packet.
+// It checks the fixed header, iterates over all FlowSets, and validates that each
+// FlowSet has a valid ID, minimum length, and remains within packet boundaries.
 func IsValidNetFlow(payload []byte, nfVersion int) (bool, error) {
-	// yes = true, no = false
+	if len(payload) < 20 {
+		return false, fmt.Errorf("payload too short for NetFlow v9 header: %d bytes", len(payload))
+	}
+
 	header := Header{}
 	reader := bytes.NewReader(payload)
-	// Parse Netflow Header
 	err := binary.Read(reader, binary.BigEndian, &header)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("failed to parse NetFlow v9 header: %w", err)
 	}
 	if header.Version != uint16(nfVersion) {
-		return false, fmt.Errorf("Header version doesn't match!  Got %d and expected %d", header.Version, nfVersion)
+		return false, fmt.Errorf("header version doesn't match: got %d, expected %d", header.Version, nfVersion)
 	}
+
+	// Validate FlowSets
+	offset := 20
+	limit := len(payload)
+	setCount := 0
+
+	// Track template record sizes for Data FlowSet record counting
+	templateRecordSizes := make(map[uint16]int)
+
+	// Deferred Data FlowSets (template not yet seen)
+	type deferredDataInfo struct {
+		fsOffset  int
+		fsID      uint16
+		fsDataLen int
+	}
+	var deferredData []deferredDataInfo
+
+	// totalMinRecords and totalMaxRecords track the range of possible record
+	// counts. Template and Options Template records are counted exactly. Data
+	// FlowSet records use countDataRecordsRange which may return a range when
+	// optional padding makes the count ambiguous (RFC 3954 §5.3, §9).
+	totalMinRecords := 0
+	totalMaxRecords := 0
+
+	for offset < limit {
+		if offset+4 > limit {
+			return false, fmt.Errorf("insufficient data for FlowSet header at offset %d", offset)
+		}
+
+		setID := binary.BigEndian.Uint16(payload[offset : offset+2])
+		setLength := binary.BigEndian.Uint16(payload[offset+2 : offset+4])
+
+		// NetFlow v9: FlowSetID 0 = Template, 1 = Options Template, >=256 = Data
+		// IDs 2-255 are reserved/unassigned
+		if setID >= 2 && setID <= 255 {
+			return false, fmt.Errorf("reserved FlowSet ID %d at offset %d", setID, offset)
+		}
+
+		if int(setLength) < 4 {
+			return false, fmt.Errorf("FlowSet length %d is less than minimum 4 at offset %d", setLength, offset)
+		}
+
+		setEnd := offset + int(setLength)
+		if setEnd > limit {
+			return false, fmt.Errorf("FlowSet at offset %d extends beyond packet boundary (end %d > length %d)", offset, setEnd, limit)
+		}
+
+		// Validate set contents based on type
+		remaining := int(setLength) - 4 // subtract FlowSet header
+		setOffset := offset + 4
+
+		switch setID {
+		case 0:
+			// Template FlowSet: one or more Template records
+			recordsParsed := 0
+			for remaining >= 4 {
+				if setOffset+4 > limit {
+					return false, fmt.Errorf("Template record header extends beyond packet at offset %d", setOffset)
+				}
+				tmplID := binary.BigEndian.Uint16(payload[setOffset : setOffset+2])
+				fieldCount := binary.BigEndian.Uint16(payload[setOffset+2 : setOffset+4])
+				if tmplID < 256 {
+					return false, fmt.Errorf("Template ID %d is below 256 at offset %d", tmplID, setOffset)
+				}
+				// Each field specifier is 4 bytes (Type + Length)
+				fieldSpecSize := int(fieldCount) * 4
+				if 4+fieldSpecSize > remaining {
+					return false, fmt.Errorf("Template record at offset %d exceeds FlowSet boundary", setOffset)
+				}
+				// Compute record size (sum of field lengths) and validate each field
+				recordSize := 0
+				for f := uint16(0); f < fieldCount; f++ {
+					fOffset := setOffset + 4 + int(f)*4
+					if fOffset+4 > limit {
+						return false, fmt.Errorf("field specifier %d extends beyond packet at offset %d", f, fOffset)
+					}
+					fLength := binary.BigEndian.Uint16(payload[fOffset+2 : fOffset+4])
+					if fLength == 0 {
+						return false, fmt.Errorf("field %d has zero length", f)
+					}
+					recordSize += int(fLength)
+				}
+				templateRecordSizes[tmplID] = recordSize
+				setOffset += 4 + fieldSpecSize
+				remaining -= 4 + fieldSpecSize
+				recordsParsed++
+			}
+			if recordsParsed == 0 {
+				return false, fmt.Errorf("Template FlowSet at offset %d contains no records", offset)
+			}
+			totalMinRecords += recordsParsed
+			totalMaxRecords += recordsParsed
+		case 1:
+			// Options Template FlowSet (RFC 3954 Section 6.1)
+			// Per-record layout:
+			//   Template ID (2 bytes) - must be >= 256
+			//   Option Scope Length (2 bytes) - total bytes of scope field specifiers
+			//   Option Length (2 bytes) - total bytes of option field specifiers
+			//   Scope Field Specifiers (Option Scope Length bytes)
+			//   Option Field Specifiers (Option Length bytes)
+			recordsParsed := 0
+			for remaining >= 6 {
+				if setOffset+6 > limit {
+					return false, fmt.Errorf("Options Template record header extends beyond packet at offset %d", setOffset)
+				}
+				tmplID := binary.BigEndian.Uint16(payload[setOffset : setOffset+2])
+				scopeLen := binary.BigEndian.Uint16(payload[setOffset+2 : setOffset+4])
+				optLen := binary.BigEndian.Uint16(payload[setOffset+4 : setOffset+6])
+
+				if tmplID < 256 {
+					return false, fmt.Errorf("Options Template ID %d is below 256 at offset %d", tmplID, setOffset)
+				}
+				// Scope and option lengths must be multiples of 4 (field specifier size)
+				if scopeLen%4 != 0 {
+					return false, fmt.Errorf("Options Template Scope Length %d is not a multiple of 4 at offset %d", scopeLen, setOffset)
+				}
+				if optLen%4 != 0 {
+					return false, fmt.Errorf("Options Template Option Length %d is not a multiple of 4 at offset %d", optLen, setOffset)
+				}
+
+				optsRecordSize := 6 + int(scopeLen) + int(optLen)
+				if optsRecordSize > remaining {
+					return false, fmt.Errorf("Options Template record at offset %d exceeds FlowSet boundary", setOffset)
+				}
+
+				// Validate scope field specifiers and sum field lengths for record size
+				optsDataSize := 0
+				scopeFieldCount := int(scopeLen) / 4
+				for s := 0; s < scopeFieldCount; s++ {
+					fOffset := setOffset + 6 + s*4
+					if fOffset+4 > limit {
+						return false, fmt.Errorf("scope field specifier %d extends beyond packet at offset %d", s, fOffset)
+					}
+					fLength := binary.BigEndian.Uint16(payload[fOffset+2 : fOffset+4])
+					if fLength == 0 {
+						return false, fmt.Errorf("scope field %d has zero length", s)
+					}
+					optsDataSize += int(fLength)
+				}
+
+				// Validate option field specifiers and sum field lengths for record size
+				optFieldCount := int(optLen) / 4
+				for o := 0; o < optFieldCount; o++ {
+					fOffset := setOffset + 6 + int(scopeLen) + o*4
+					if fOffset+4 > limit {
+						return false, fmt.Errorf("option field specifier %d extends beyond packet at offset %d", o, fOffset)
+					}
+					fLength := binary.BigEndian.Uint16(payload[fOffset+2 : fOffset+4])
+					if fLength == 0 {
+						return false, fmt.Errorf("option field %d has zero length", o)
+					}
+					optsDataSize += int(fLength)
+				}
+
+				templateRecordSizes[tmplID] = optsDataSize
+				setOffset += optsRecordSize
+				remaining -= optsRecordSize
+				recordsParsed++
+			}
+			if recordsParsed == 0 {
+				return false, fmt.Errorf("Options Template FlowSet at offset %d contains no records", offset)
+			}
+			totalMinRecords += recordsParsed
+			totalMaxRecords += recordsParsed
+		default:
+			// Data FlowSet (ID >= 256): records match a Template
+			// A Data FlowSet must contain at least one record; a record can be
+			// as small as a single 1-byte field. RFC 3954 §5.3 recommends
+			// 32-bit padding but does not require it.
+			if remaining < 1 {
+				return false, fmt.Errorf("Data FlowSet at offset %d is too small to contain records", offset)
+			}
+			// Use template record size to count actual records
+			if rs, ok := templateRecordSizes[setID]; ok && rs > 0 {
+				minCount, maxCount := countDataRecordsRange(remaining, rs)
+				if minCount < 0 {
+					return false, fmt.Errorf("Data FlowSet at offset %d has invalid record layout for template %d", offset, setID)
+				}
+				totalMinRecords += minCount
+				totalMaxRecords += maxCount
+			} else {
+				// Template not yet seen; defer counting
+				deferredData = append(deferredData, deferredDataInfo{
+					fsOffset:  offset,
+					fsID:      setID,
+					fsDataLen: remaining,
+				})
+			}
+		}
+
+		// Validate padding for Template and Options Template FlowSets only
+		if setID <= 1 && remaining > 0 {
+			for i := 0; i < remaining; i++ {
+				if payload[setOffset+i] != 0 {
+					return false, fmt.Errorf("non-zero padding byte at offset %d in FlowSet %d", setOffset+i, offset)
+				}
+			}
+		}
+
+		setCount++
+		offset = setEnd
+	}
+
+	// Process deferred Data FlowSets now that all templates are known.
+	// Data-only packets (template sent in a prior packet) are accepted;
+	// their records can't be counted without the template. Each unresolved
+	// Data FlowSet must contain at least one record.
+	hasUnresolvedData := false
+	for _, info := range deferredData {
+		rs, ok := templateRecordSizes[info.fsID]
+		if !ok || rs == 0 {
+			// Template not in this packet; count at least 1 record per FlowSet.
+			// The upper bound is unknown, so we can't enforce it.
+			hasUnresolvedData = true
+			totalMinRecords++
+			continue
+		}
+		minCount, maxCount := countDataRecordsRange(info.fsDataLen, rs)
+		if minCount < 0 {
+			return false, fmt.Errorf("Data FlowSet at offset %d has invalid record layout for template %d", info.fsOffset, info.fsID)
+		}
+		totalMinRecords += minCount
+		totalMaxRecords += maxCount
+	}
+
+	if setCount == 0 {
+		return false, fmt.Errorf("NetFlow v9 packet contains no FlowSets")
+	}
+
+	// Validate header FlowCount against the range of possible record counts.
+	// When padding makes the count ambiguous, the header resolves which
+	// interpretation is correct (RFC 3954 §9).
+	if header.FlowCount == 0 {
+		return false, fmt.Errorf("header FlowCount is zero")
+	}
+	if totalMinRecords > math.MaxUint16 {
+		return false, fmt.Errorf("record count %d exceeds FlowCount field capacity", totalMinRecords)
+	}
+	// When templates are missing, the upper bound is unknown; only enforce
+	// the lower bound. When all templates are known, enforce the full range.
+	if hasUnresolvedData {
+		if int(header.FlowCount) < totalMinRecords {
+			return false, fmt.Errorf("header FlowCount %d is less than minimum record count %d", header.FlowCount, totalMinRecords)
+		}
+	} else {
+		if int(header.FlowCount) < totalMinRecords || int(header.FlowCount) > totalMaxRecords {
+			return false, fmt.Errorf("header FlowCount %d is outside valid range [%d, %d]", header.FlowCount, totalMinRecords, totalMaxRecords)
+		}
+	}
+
 	return true, nil
 }
 

--- a/netflow/validator_fuzz_test.go
+++ b/netflow/validator_fuzz_test.go
@@ -1,0 +1,65 @@
+// Use of this source code is governed by Apache License 2.0
+// that can be found in the LICENSE file.
+
+package netflow
+
+import "testing"
+
+func FuzzIsValidNetFlow(f *testing.F) {
+	// Add seed corpus with known valid packets
+	session := NewSession()
+
+	// Template-only packet
+	tmplFlow := GenerateTemplateNetflow(618, session)
+	tmplBuf := tmplFlow.ToBytes()
+	f.Add(tmplBuf.Bytes())
+
+	// Template + data packet
+	nf, err := GenerateNetflow(5, 618, "10.0.0.0/8", "10.0.0.0/8", session)
+	if err != nil {
+		f.Fatal(err)
+	}
+	nfBuf := nf.ToBytes()
+	f.Add(nfBuf.Bytes())
+
+	// Data-only packet
+	dataFlow, err := GenerateDataNetflow(3, 618, "10.0.0.0/8", "10.0.0.0/8", 443, session)
+	if err != nil {
+		f.Fatal(err)
+	}
+	dataBuf := dataFlow.ToBytes()
+	f.Add(dataBuf.Bytes())
+
+	// Minimal valid packet: header + template with 1 field
+	f.Add([]byte{
+		0x00, 0x09, // version 9
+		0x00, 0x01, // flowCount 1
+		0x00, 0x00, 0x03, 0xE8, // SysUptime 1000
+		0x00, 0x00, 0x00, 0x00, // UnixSec 0
+		0x00, 0x00, 0x00, 0x01, // FlowSequence 1
+		0x00, 0x00, 0x02, 0x6A, // SourceID 618
+		// Template FlowSet (ID=0), length=12 (4 header + 2 tmplID + 2 fieldCount + 4 field)
+		0x00, 0x00, // FlowSetID 0
+		0x00, 0x0C, // Length 12
+		0x01, 0x00, // TemplateID 256
+		0x00, 0x01, // FieldCount 1
+		0x00, 0x01, // Field type 1
+		0x00, 0x04, // Field length 4
+	})
+
+	// Short payload (too short for header)
+	f.Add([]byte{0x00, 0x09, 0x00})
+
+	// Empty payload
+	f.Add([]byte{})
+
+	// Random-looking bytes
+	f.Add([]byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+		0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+		0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// IsValidNetFlow should never panic on any input
+		IsValidNetFlow(data, 9)
+	})
+}

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -263,6 +263,86 @@ func TestParseNetflow(t *testing.T) {
 	close(dataChan)
 }
 
+// TestParseNetflow_MalformedNetFlow verifies that packets with a valid version-9
+// header but malformed FlowSets are rejected and not forwarded.
+func TestParseNetflow_MalformedNetFlow(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var wg sync.WaitGroup
+
+	proxyChan := make(chan []byte, bufferSize)
+	dataChan := make(chan []byte, bufferSize)
+	rStats := &stats.RecordStat{}
+
+	done := make(chan struct{})
+	wg.Add(1)
+	go func() {
+		parseNetflow(ctx, &wg, proxyChan, dataChan, rStats, false)
+		close(done)
+	}()
+
+	// Build a packet with a valid v9 header but a FlowSet with reserved ID (2)
+	var buf bytes.Buffer
+	// Header: version=9, flowCount=1
+	buf.Write([]byte{0x00, 0x09, 0x00, 0x01})
+	buf.Write([]byte{0x00, 0x00, 0x03, 0xE8}) // SysUptime
+	buf.Write([]byte{0x00, 0x00, 0x3B, 0x9A}) // UnixSec
+	buf.Write([]byte{0x00, 0x00, 0x00, 0x01}) // FlowSequence
+	buf.Write([]byte{0x00, 0x00, 0x02, 0x6A}) // SourceID
+	// Reserved FlowSet ID 2 (must be rejected)
+	buf.Write([]byte{0x00, 0x02}) // FlowSetID (reserved)
+	buf.Write([]byte{0x00, 0x08}) // Length
+	buf.Write([]byte{0x00, 0x00, 0x00, 0x00})
+
+	malformed := buf.Bytes()
+	valid, _ := netflow.IsValidNetFlow(malformed, 9)
+	if valid {
+		t.Fatal("malformed packet should not pass validation")
+	}
+
+	// Send malformed packet — it should be counted as invalid and not forwarded
+	proxyChan <- malformed
+
+	time.Sleep(100 * time.Millisecond)
+
+	if rStats.LoadInvalid() != 1 {
+		t.Errorf("Expected 1 invalid packet for malformed NetFlow, got %d", rStats.LoadInvalid())
+	}
+
+	// Verify it was not forwarded
+	select {
+	case <-dataChan:
+		t.Error("malformed NetFlow packet with reserved FlowSet ID should not be forwarded")
+	case <-time.After(200 * time.Millisecond):
+		// Expected: packet was rejected
+	}
+
+	// Send a valid packet to confirm the parser still works
+	session := netflow.NewSession()
+	flow := netflow.GenerateTemplateNetflow(100, session)
+	flowBuf := flow.ToBytes()
+	proxyChan <- flowBuf.Bytes()
+
+	select {
+	case <-dataChan:
+		// Good, valid packet was forwarded
+	case <-time.After(2 * time.Second):
+		t.Error("Timeout waiting for valid packet to be forwarded")
+	}
+
+	if rStats.LoadValid() != 1 {
+		t.Errorf("Expected 1 valid packet, got %d", rStats.LoadValid())
+	}
+
+	cancel()
+	wg.Wait()
+	close(proxyChan)
+	close(dataChan)
+}
+
 // TestStatsPrinter tests that stats are printed periodically.
 func TestStatsPrinter(t *testing.T) {
 	t.Parallel()

--- a/record/record_test.go
+++ b/record/record_test.go
@@ -6,6 +6,7 @@ package record
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"net"
 	"os"
 	"sync"
@@ -142,6 +143,75 @@ func TestParseFlow(t *testing.T) {
 	parseChan <- buf.Bytes()
 
 	// Wait for processing
+	select {
+	case <-dataChan:
+		// Good, valid packet was forwarded
+	case <-time.After(2 * time.Second):
+		t.Error("Timeout waiting for valid packet to be forwarded")
+	}
+
+	// Cleanup
+	cancel()
+	wg.Wait()
+	close(parseChan)
+	close(dataChan)
+}
+
+// TestParseFlow_MalformedNetFlow verifies that packets with a valid version-9
+// header but malformed FlowSets are rejected and not stored.
+func TestParseFlow_MalformedNetFlow(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var wg sync.WaitGroup
+
+	parseChan := make(chan []byte, 1024)
+	dataChan := make(chan []byte, 1024)
+
+	done := make(chan struct{})
+	wg.Add(1)
+	go func() {
+		parseFlow(ctx, &wg, parseChan, dataChan, false)
+		close(done)
+	}()
+
+	// Build a packet with a valid v9 header but a FlowSet with reserved ID (2)
+	var buf bytes.Buffer
+	binary.Write(&buf, binary.BigEndian, uint16(9))   // version
+	binary.Write(&buf, binary.BigEndian, uint16(1))   // flowCount
+	binary.Write(&buf, binary.BigEndian, uint32(1000)) // SysUptime
+	binary.Write(&buf, binary.BigEndian, uint32(1000000)) // UnixSec
+	binary.Write(&buf, binary.BigEndian, uint32(1))    // FlowSequence
+	binary.Write(&buf, binary.BigEndian, uint32(618))  // SourceID
+	// Reserved FlowSet ID 2 (must be rejected)
+	binary.Write(&buf, binary.BigEndian, uint16(2))    // FlowSetID (reserved)
+	binary.Write(&buf, binary.BigEndian, uint16(8))    // Length
+	binary.Write(&buf, binary.BigEndian, uint32(0))    // padding
+
+	malformed := buf.Bytes()
+	valid, _ := netflow.IsValidNetFlow(malformed, 9)
+	if valid {
+		t.Fatal("malformed packet should not pass validation")
+	}
+
+	// Send malformed packet — it should not appear on dataChan
+	parseChan <- malformed
+
+	select {
+	case <-dataChan:
+		t.Error("malformed NetFlow packet with reserved FlowSet ID should not be forwarded")
+	case <-time.After(200 * time.Millisecond):
+		// Expected: packet was rejected
+	}
+
+	// Send a valid packet to confirm the parser still works
+	session := netflow.NewSession()
+	flow := netflow.GenerateTemplateNetflow(100, session)
+	flowBuf := flow.ToBytes()
+	parseChan <- flowBuf.Bytes()
+
 	select {
 	case <-dataChan:
 		// Good, valid packet was forwarded


### PR DESCRIPTION
## Summary

Fixes all remaining F-08 (NetFlow v9 validation) findings from the code quality and security review.

## Changes

### Options Template FlowSet parsing (RFC 3954 Section 6.1)
- Corrected record header from 8 bytes to 6 bytes: Template ID (2), Option Scope Length (2), Option Length (2)
- Added validation of scope and option field specifiers using length values
- Store Options Template record sizes to enable counting Options Data FlowSet records

### FlowCount accuracy
- Implement range-based record counting (`countDataRecordsRange`) returning [min, max] for all valid padding interpretations (0-3 bytes)
- Header FlowCount resolves ambiguous cases per RFC 3954 Section 9
- Both padded (1 record + 3 padding) and unpadded (4 records + 0 padding) short-record cases accepted when FlowCount is consistent
- Fix `GenerateDataNetflow` to use actual flowCount instead of hardcoded 1

### Safety and correctness
- Lower Data FlowSet minimum from 4 to 1 byte (RFC allows 1-byte fields; padding is recommended but not required)
- Unresolved Data FlowSets contribute at least 1 record to lower-bound
- Guard `uint16(totalRecords)` against `math.MaxUint16` overflow

### Testing
- Add fuzz test (`FuzzIsValidNetFlow`) with seed corpus for all packet types
- Strengthen record/proxy malformed-packet integration tests with version-9 headers and reserved FlowSet IDs
- Add tests for padded/unpadded short records, Options Data counting, mixed known/unknown templates, and FlowCount range validation

## Verification

- `go test ./... -count 1` — all 13 packages pass
- `go test -race ./... -count 1` — all packages pass with race detector
- `go vet ./...` — clean
- `gofmt -l .` — clean
- Fuzz testing: 1.1M+ executions with zero panics