### PR TITLE
Fix: Restore runtime lifecycle and security hardening

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -12,15 +12,13 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
     if: github.actor == 'dependabot[bot]' && github.event.pull_request.draft == false
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: '1.26'
 

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: Set up Go
-      uses: actions/setup-go@0c52d547c9bc32b1aa3d3115734e3b125f11e2e1 # v5.0.0
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: '1.26'
         cache: true

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -11,15 +11,13 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
     - name: Set up Go
-      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
       with:
         go-version: '1.26'
         cache: true

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -16,17 +16,26 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@0c52d547c9bc32b1aa3d3115734e3b125f11e2e1 # v5.0.0
       with:
         go-version: '1.26'
         cache: true
 
     - name: Ensure go.mod is tidy
-      run: go mod tidy
+      run: |
+        go mod tidy
+        git diff --exit-code -- go.mod go.sum
+
+    - name: Run go vet
+      run: go vet ./...
+
     - name: Run tests
       run: |
         go test -v ./... -count 1
         go build
+
+    - name: Run tests with race detector
+      run: go test -race ./... -count 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: Set up Go
-      uses: actions/setup-go@0c52d547c9bc32b1aa3d3115734e3b125f11e2e1 # v5.0.0
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: '1.26'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,10 @@ jobs:
       VERSION: "${{ github.ref_name }}"
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@0c52d547c9bc32b1aa3d3115734e3b125f11e2e1 # v5.0.0
       with:
         go-version: '1.26'
 
@@ -55,10 +55,19 @@ jobs:
 
     - name: Install nfpm
       run: |
-        curl -sSfL https://github.com/goreleaser/nfpm/releases/download/v2.46.3/nfpm_2.46.3_linux_amd64.deb -o nfpm.deb || \
-        curl -sSfL https://github.com/goreleaser/nfpm/releases/download/v2.46.3/nfpm_2.46.3_amd64.deb -o nfpm.deb
+        NFPM_VERSION="2.46.3"
+        NFPM_DEB="nfpm_${NFPM_VERSION}_amd64.deb"
+        curl -sSfL "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/${NFPM_DEB}" -o nfpm.deb
+        curl -sSfL "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/checksums.txt" -o checksums.txt
+        EXPECTED_SHA="$(grep "${NFPM_DEB}" checksums.txt | awk '{print $1}')"
+        if [ -n "$EXPECTED_SHA" ]; then
+          echo "$EXPECTED_SHA  nfpm.deb" | sha256sum -c -
+        else
+          echo "ERROR: checksum not found in checksums.txt for ${NFPM_DEB}"
+          exit 1
+        fi
         sudo apt-get install -y ./nfpm.deb
-        rm -f nfpm.deb
+        rm -f nfpm.deb checksums.txt
 
     - name: Package RPM and DEB
       env:
@@ -76,12 +85,24 @@ jobs:
     - name: Generate SBOM
       run: |
         mkdir -p ./bin
-        TRIVY_VERSION="v0.70.0"
-        curl -sSfL https://github.com/aquasecurity/trivy/releases/download/${TRIVY_VERSION}/trivy_${TRIVY_VERSION#v}_Linux-64bit.tar.gz | tar xz && mv trivy ./bin/
+        TRIVY_VERSION="0.70.0"
+        TRIVY_ARCHIVE="trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
+        CHECKSUMS="trivy_${TRIVY_VERSION}_checksums.txt"
+        curl -sSfL "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/${TRIVY_ARCHIVE}" -o "${TRIVY_ARCHIVE}"
+        curl -sSfL "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/${CHECKSUMS}" -o "${CHECKSUMS}"
+        EXPECTED_SHA="$(grep "${TRIVY_ARCHIVE}" "${CHECKSUMS}" | awk '{print $1}')"
+        if [ -n "$EXPECTED_SHA" ]; then
+          echo "$EXPECTED_SHA  ${TRIVY_ARCHIVE}" | sha256sum -c -
+        else
+          echo "ERROR: checksum not found in ${CHECKSUMS} for ${TRIVY_ARCHIVE}"
+          exit 1
+        fi
+        tar xzf "${TRIVY_ARCHIVE}" && mv trivy ./bin/
+        rm -f "${TRIVY_ARCHIVE}" "${CHECKSUMS}"
         ./bin/trivy fs --format cyclonedx --output sbom_${{ env.VERSION }}.json .
 
     - name: Create GitHub Release
-      uses: softprops/action-gh-release@26994186c0ac3ef5cae75ac16aa32e8153525f77
+      uses: softprops/action-gh-release@26994186c0ac3ef5cae75ac16aa32e8153525f77 # v2.0.6
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         files: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,14 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
       VERSION: "${{ github.ref_name }}"
     steps:
     - name: Checkout code
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
     - name: Set up Go
-      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
       with:
         go-version: '1.26'
 
@@ -102,7 +101,7 @@ jobs:
         ./bin/trivy fs --format cyclonedx --output sbom_${{ env.VERSION }}.json .
 
     - name: Create GitHub Release
-      uses: softprops/action-gh-release@26994186c0ac3ef5cae75ac16aa32e8153525f77 # v2.0.6
+      uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         files: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: Set up Go
-      uses: actions/setup-go@0c52d547c9bc32b1aa3d3115734e3b125f11e2e1 # v5.0.0
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: '1.26'
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,10 +1,12 @@
 name: Security
 
 on:
-  pull_request: {}
   push:
+    branches:
+      - main
     tags:
       - 'v*'
+  pull_request: {}
 
 jobs:
   security:
@@ -13,10 +15,10 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@0c52d547c9bc32b1aa3d3115734e3b125f11e2e1 # v5.0.0
       with:
         go-version: '1.26'
 
@@ -30,7 +32,7 @@ jobs:
         go install github.com/securego/gosec/v2/cmd/gosec@v2.22.2
         gosec -exclude=G115 ./...
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@bfa4b33a029b9aa80ddb784b45574c30e072c59e
+      uses: aquasecurity/trivy-action@bfa4b33a029b9aa80ddb784b45574c30e072c59e # 0.24.0
       with:
         scan-type: 'fs'
         severity: 'CRITICAL,HIGH'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,14 +11,12 @@ on:
 jobs:
   security:
     runs-on: ubuntu-latest
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
     steps:
     - name: Checkout code
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
     - name: Set up Go
-      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
       with:
         go-version: '1.26'
 

--- a/barrage/barrage.go
+++ b/barrage/barrage.go
@@ -219,15 +219,10 @@ func RunCtx(ctx context.Context, config *models.Config, gen FlowGenerator) {
 // Use RunCtx() when you need to control the lifecycle via context.
 func Run(config *models.Config, gen FlowGenerator) {
 	mgr := lifecycle.New()
+	defer mgr.Cancel()
 
 	// Setup signal handling via lifecycle manager
-	cleanupDone := mgr.SetupSignalHandler()
-
-	go func() {
-		<-cleanupDone
-		log.Printf("Received signal, shutting down...\n")
-		mgr.Cancel()
-	}()
+	_ = mgr.SetupSignalHandler()
 
 	RunCtx(mgr.Context(), config, gen)
 	mgr.Wait()

--- a/cmd/barrage.go
+++ b/cmd/barrage.go
@@ -12,7 +12,7 @@ import (
 	"os"
 
 	"github.com/dmabry/flowgre/barrage"
-	"github.com/dmabry/flowgre/config"
+	flowgreconfig "github.com/dmabry/flowgre/config"
 	"github.com/dmabry/flowgre/lifecycle"
 	"github.com/dmabry/flowgre/models"
 	"github.com/dmabry/flowgre/netflow"
@@ -37,6 +37,8 @@ type BarrageCommand struct {
 	profile          *string
 	webUsername      *string
 	webPassword      *string
+	tlsCert          *string
+	tlsKey           *string
 }
 
 // ParseFlags parses command-line flags for the barrage mode.
@@ -57,6 +59,8 @@ func (c *BarrageCommand) ParseFlags(args []string) error {
 	c.profile = fs.String("profile", "generic", "flow profile: generic, minimal, extended")
 	c.webUsername = fs.String("web-username", "", "Web server username (default: env FLOWGRE_WEB_USERNAME or generated)")
 	c.webPassword = fs.String("web-password", "", "Web server password (default: env FLOWGRE_WEB_PASSWORD or generated)")
+	c.tlsCert = fs.String("tls-cert", "", "TLS certificate file for web server (required for non-loopback binding)")
+	c.tlsKey = fs.String("tls-key", "", "TLS key file for web server (required for non-loopback binding)")
 	return fs.Parse(args)
 }
 
@@ -164,11 +168,11 @@ func (c *BarrageCommand) Execute() error {
 	// Load configuration from file or CLI flags
 	if *c.configFile != "" {
 		fmt.Println("Reading config file... ignoring any other given arguments")
-		if err := config.InitViper(*c.configFile); err != nil {
+		if err := flowgreconfig.InitViper(*c.configFile); err != nil {
 			return fmt.Errorf("error reading config file: %w", err)
 		}
 		var err error
-		cfg, err = config.LoadBarrageConfig()
+		cfg, err = flowgreconfig.LoadBarrageConfig()
 		if err != nil {
 			return fmt.Errorf("error loading barrage config: %w", err)
 		}
@@ -200,10 +204,22 @@ func (c *BarrageCommand) Execute() error {
 		return err
 	}
 
+	// Validate barrage configuration before starting any goroutines
+	if err := flowgreconfig.ValidateBarrage(cfg.Server, cfg.DstPort, cfg.SrcRange, cfg.DstRange, cfg.Workers, cfg.Delay, cfg.TemplateInterval); err != nil {
+		return fmt.Errorf("validate barrage config: %w", err)
+	}
+
 	// Validate web binding safety
 	if cfg.Web {
 		if err := validateWebBinding(cfg.WebIP, cfg.WebUsername, cfg.WebPassword); err != nil {
 			return err
+		}
+		if err := flowgreconfig.ValidateWeb(effectiveWebIP(cfg.WebIP), cfg.WebPort); err != nil {
+			return fmt.Errorf("validate web config: %w", err)
+		}
+		// Validate TLS binding before starting workers
+		if err := web.ValidateWebBinding(effectiveWebIP(cfg.WebIP), *c.tlsCert, *c.tlsKey); err != nil {
+			return fmt.Errorf("validate web TLS: %w", err)
 		}
 	}
 
@@ -228,13 +244,8 @@ func (c *BarrageCommand) Execute() error {
 
 	// Setup lifecycle and signal handling
 	mgr := lifecycle.New()
-	cleanupDone := mgr.SetupSignalHandler()
-
-	go func() {
-		<-cleanupDone
-		log.Printf("Received signal, shutting down...\n")
-		mgr.Cancel()
-	}()
+	defer mgr.Cancel()
+	_ = mgr.SetupSignalHandler()
 
 	// Start barrage workers
 	opts := barrage.StartCtx(mgr.Context(), cfg, gen)
@@ -243,7 +254,7 @@ func (c *BarrageCommand) Execute() error {
 	if cfg.Web {
 		opts.Wg.Add(1)
 		effectiveIP := effectiveWebIP(cfg.WebIP)
-		go web.RunWebServer(effectiveIP, cfg.WebPort, opts.Wg, mgr.Context(), opts.Stats, webUsername, webHashedPassword)
+		go web.RunWebServer(effectiveIP, cfg.WebPort, opts.Wg, mgr.Context(), opts.Stats, webUsername, webHashedPassword, *c.tlsCert, *c.tlsKey)
 	}
 
 	opts.Wg.Wait()

--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -6,8 +6,11 @@ package cmd
 
 import (
 	"flag"
+	"fmt"
 	"os"
 
+	"github.com/dmabry/flowgre/config"
+	"github.com/dmabry/flowgre/lifecycle"
 	"github.com/dmabry/flowgre/proxy"
 )
 
@@ -42,8 +45,18 @@ func (c *ProxyCommand) ParseFlags(args []string) error {
 }
 
 // Execute runs the proxy mode with parsed flags.
-func (c *ProxyCommand) Execute() {
-	proxy.Run(*c.ip, *c.port, *c.verbose, []string(c.targets))
+func (c *ProxyCommand) Execute() error {
+	targets := []string(c.targets)
+	if err := config.ValidateProxy(*c.ip, *c.port, targets); err != nil {
+		return fmt.Errorf("validate proxy config: %w", err)
+	}
+	mgr := lifecycle.New()
+	defer mgr.Cancel()
+	_ = mgr.SetupSignalHandler()
+	if err := proxy.RunCtx(mgr.Context(), *c.ip, *c.port, *c.verbose, targets); err != nil {
+		return fmt.Errorf("proxy: %w", err)
+	}
+	return nil
 }
 
 // RunProxy is the entry point for the proxy subcommand.
@@ -52,5 +65,8 @@ func RunProxy(args []string) {
 	if err := c.ParseFlags(args); err != nil {
 		os.Exit(1)
 	}
-	c.Execute()
+	if err := c.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "proxy: %v\n", err)
+		os.Exit(1)
+	}
 }

--- a/cmd/record.go
+++ b/cmd/record.go
@@ -6,8 +6,11 @@ package cmd
 
 import (
 	"flag"
+	"fmt"
 	"os"
 
+	"github.com/dmabry/flowgre/config"
+	"github.com/dmabry/flowgre/lifecycle"
 	"github.com/dmabry/flowgre/record"
 )
 
@@ -30,8 +33,17 @@ func (c *RecordCommand) ParseFlags(args []string) error {
 }
 
 // Execute runs the record mode with parsed flags.
-func (c *RecordCommand) Execute() {
-	record.Run(*c.ip, *c.port, *c.dbDir, *c.verbose)
+func (c *RecordCommand) Execute() error {
+	if err := config.ValidateRecord(*c.ip, *c.port, *c.dbDir); err != nil {
+		return fmt.Errorf("validate record config: %w", err)
+	}
+	mgr := lifecycle.New()
+	_ = mgr.SetupSignalHandler()
+	defer mgr.Cancel()
+	if err := record.RunCtx(mgr.Context(), *c.ip, *c.port, *c.dbDir, *c.verbose); err != nil {
+		return fmt.Errorf("record: %w", err)
+	}
+	return nil
 }
 
 // RunRecord is the entry point for the record subcommand.
@@ -40,5 +52,8 @@ func RunRecord(args []string) {
 	if err := c.ParseFlags(args); err != nil {
 		os.Exit(1)
 	}
-	c.Execute()
+	if err := c.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "record: %v\n", err)
+		os.Exit(1)
+	}
 }

--- a/cmd/replay.go
+++ b/cmd/replay.go
@@ -6,8 +6,11 @@ package cmd
 
 import (
 	"flag"
+	"fmt"
 	"os"
 
+	"github.com/dmabry/flowgre/config"
+	"github.com/dmabry/flowgre/lifecycle"
 	"github.com/dmabry/flowgre/replay"
 )
 
@@ -38,8 +41,17 @@ func (c *ReplayCommand) ParseFlags(args []string) error {
 }
 
 // Execute runs the replay mode with parsed flags.
-func (c *ReplayCommand) Execute() {
-	replay.Run(*c.server, *c.port, *c.delay, *c.dbDir, *c.loop, *c.workers, *c.updateTS, *c.verbose)
+func (c *ReplayCommand) Execute() error {
+	if err := config.ValidateReplay(*c.server, *c.port, *c.delay, *c.dbDir, *c.workers); err != nil {
+		return fmt.Errorf("validate replay config: %w", err)
+	}
+	mgr := lifecycle.New()
+	defer mgr.Cancel()
+	_ = mgr.SetupSignalHandler()
+	if err := replay.RunCtx(mgr.Context(), *c.server, *c.port, *c.delay, *c.dbDir, *c.loop, *c.workers, *c.updateTS, *c.verbose); err != nil {
+		return fmt.Errorf("replay: %w", err)
+	}
+	return nil
 }
 
 // RunReplay is the entry point for the replay subcommand.
@@ -48,5 +60,8 @@ func RunReplay(args []string) {
 	if err := c.ParseFlags(args); err != nil {
 		os.Exit(1)
 	}
-	c.Execute()
+	if err := c.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "replay: %v\n", err)
+		os.Exit(1)
+	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -59,14 +59,29 @@ func LoadBarrageConfig() (*models.Config, error) {
 
 	// Extract values with defaults
 	ip := getString(targetValues, "ip", "127.0.0.1")
-	port := getInt(targetValues, "port", 9995)
-	workers := getInt(targetValues, "workers", 4)
-	delay := getInt(targetValues, "delay", 100)
+	port, err := getInt(targetValues, "port", 9995)
+	if err != nil {
+		return nil, err
+	}
+	workers, err := getInt(targetValues, "workers", 4)
+	if err != nil {
+		return nil, err
+	}
+	delay, err := getInt(targetValues, "delay", 100)
+	if err != nil {
+		return nil, err
+	}
 	srcRange := getString(targetValues, "src-range", "10.0.0.0/8")
 	dstRange := getString(targetValues, "dst-range", "10.0.0.0/8")
-	templateInterval := getInt(targetValues, "template-interval", 30)
+	templateInterval, err := getInt(targetValues, "template-interval", 30)
+	if err != nil {
+		return nil, err
+	}
 	webIP := getString(targetValues, "web-ip", "127.0.0.1")
-	webPort := getInt(targetValues, "web-port", 8080)
+	webPort, err := getInt(targetValues, "web-port", 8080)
+	if err != nil {
+		return nil, err
+	}
 	web := getBool(targetValues, "web", false)
 	protocol := getString(targetValues, "protocol", "netflow")
 	webUsername := getString(targetValues, "web-username", "")
@@ -104,25 +119,31 @@ func getString(m map[string]any, key, def string) string {
 
 // getInt safely gets an int value from a map with a default.
 // Viper returns float64 for numbers, so we handle that.
-func getInt(m map[string]any, key string, def int) int {
+// Returns an error if the value is a fractional number or invalid type.
+func getInt(m map[string]any, key string, def int) (int, error) {
 	if v, ok := m[key]; ok {
 		switch val := v.(type) {
 		case int:
-			return val
+			return val, nil
 		case int64:
-			return int(val)
+			return int(val), nil
 		case float64:
-			return int(val)
+			// Check for fractional value
+			if val != float64(int(val)) {
+				return 0, fmt.Errorf("config value %q is fractional: %v", key, val)
+			}
+			return int(val), nil
 		case string:
-			// Try to parse as int
 			result, err := strconv.Atoi(val)
 			if err != nil {
-				return def
+				return 0, fmt.Errorf("config value %q is not a valid integer: %q", key, val)
 			}
-			return result
+			return result, nil
+		default:
+			return 0, fmt.Errorf("config value %q has unexpected type: %T", key, val)
 		}
 	}
-	return def
+	return def, nil
 }
 
 // getBool safely gets a bool value from a map with a default.

--- a/config/validate.go
+++ b/config/validate.go
@@ -1,0 +1,157 @@
+// Use of this source code is governed by Apache License 2.0
+// that can be found in the LICENSE file.
+
+// Package config provides centralized validation for command-line and YAML
+// configuration before any goroutine, socket, or database is started.
+package config
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+)
+
+// ValidateRecord validates record command configuration.
+func ValidateRecord(ip string, port int, dbdir string) error {
+	if err := validateListenerIP(ip); err != nil {
+		return fmt.Errorf("record listener IP: %w", err)
+	}
+	if err := validatePort(port, false); err != nil {
+		return fmt.Errorf("record listener port: %w", err)
+	}
+	if dbdir == "" {
+		return fmt.Errorf("record database directory is required")
+	}
+	return nil
+}
+
+// ValidateReplay validates replay command configuration.
+func ValidateReplay(server string, port int, delay int, dbdir string, workers int) error {
+	if err := validateDestIP(server); err != nil {
+		return fmt.Errorf("replay destination IP: %w", err)
+	}
+	if err := validatePort(port, false); err != nil {
+		return fmt.Errorf("replay destination port: %w", err)
+	}
+	if delay <= 0 {
+		return fmt.Errorf("replay delay must be positive, got %d", delay)
+	}
+	if dbdir == "" {
+		return fmt.Errorf("replay database directory is required")
+	}
+	if workers < 1 {
+		return fmt.Errorf("replay workers must be at least 1, got %d", workers)
+	}
+	return nil
+}
+
+// ValidateBarrage validates barrage command configuration.
+func ValidateBarrage(server string, port int, srcRange, dstRange string, workers, delay, templateInterval int) error {
+	if err := validateDestIP(server); err != nil {
+		return fmt.Errorf("barrage destination IP: %w", err)
+	}
+	if err := validatePort(port, false); err != nil {
+		return fmt.Errorf("barrage destination port: %w", err)
+	}
+	if err := validateCIDR(srcRange, "src-range"); err != nil {
+		return err
+	}
+	if err := validateCIDR(dstRange, "dst-range"); err != nil {
+		return err
+	}
+	if workers < 1 {
+		return fmt.Errorf("barrage workers must be at least 1, got %d", workers)
+	}
+	if delay <= 0 {
+		return fmt.Errorf("barrage delay must be positive, got %d", delay)
+	}
+	if templateInterval < 0 {
+		return fmt.Errorf("barrage template-interval must be 0 (disabled) or positive, got %d", templateInterval)
+	}
+	return nil
+}
+
+// ValidateProxy validates proxy command configuration.
+func ValidateProxy(ip string, port int, targets []string) error {
+	if err := validateListenerIP(ip); err != nil {
+		return fmt.Errorf("proxy listener IP: %w", err)
+	}
+	if err := validatePort(port, false); err != nil {
+		return fmt.Errorf("proxy listener port: %w", err)
+	}
+	if len(targets) == 0 {
+		return fmt.Errorf("proxy requires at least one target")
+	}
+	if len(targets) > 10 {
+		return fmt.Errorf("proxy supports at most 10 targets, got %d", len(targets))
+	}
+	for _, target := range targets {
+		host, p, err := net.SplitHostPort(target)
+		if err != nil {
+			return fmt.Errorf("proxy target %q: %w", target, err)
+		}
+		if err := validateDestIP(host); err != nil {
+			return fmt.Errorf("proxy target %q IP: %w", target, err)
+		}
+		portInt, err := strconv.Atoi(p)
+		if err != nil {
+			return fmt.Errorf("proxy target %q port is not a valid integer: %q", target, p)
+		}
+		if portInt < 1 || portInt > 65535 {
+			return fmt.Errorf("proxy target %q port %d out of range 1-65535", target, portInt)
+		}
+	}
+	return nil
+}
+
+// ValidateWeb validates web server configuration.
+func ValidateWeb(ip string, port int) error {
+	if err := validateListenerIP(ip); err != nil {
+		return fmt.Errorf("web listener IP: %w", err)
+	}
+	if err := validatePort(port, false); err != nil {
+		return fmt.Errorf("web listener port: %w", err)
+	}
+	return nil
+}
+
+// validateListenerIP validates an IP address used for listening.
+func validateListenerIP(ip string) error {
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return fmt.Errorf("invalid IP address: %q", ip)
+	}
+	return nil
+}
+
+// validateDestIP validates an IP address used as a destination.
+func validateDestIP(ip string) error {
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return fmt.Errorf("invalid IP address: %q", ip)
+	}
+	return nil
+}
+
+// validatePort validates a port number. ephemeral allows 0 for source ports.
+func validatePort(port int, ephemeral bool) error {
+	if ephemeral {
+		if port < 0 || port > 65535 {
+			return fmt.Errorf("port %d out of range 0-65535", port)
+		}
+		return nil
+	}
+	if port < 1 || port > 65535 {
+		return fmt.Errorf("port %d out of range 1-65535", port)
+	}
+	return nil
+}
+
+// validateCIDR validates a CIDR notation string.
+func validateCIDR(cidr, name string) error {
+	_, _, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return fmt.Errorf("invalid %s CIDR %q: %w", name, cidr, err)
+	}
+	return nil
+}

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -1,0 +1,144 @@
+// Use of this source code is governed by Apache License 2.0
+// that can be found in the LICENSE file.
+
+package config
+
+import "testing"
+
+func TestValidateRecord(t *testing.T) {
+	tests := []struct {
+		name    string
+		ip      string
+		port    int
+		dbdir   string
+		wantErr bool
+	}{
+		{"valid", "127.0.0.1", 9995, "/tmp/db", false},
+		{"valid IPv6", "::1", 9995, "/tmp/db", false},
+		{"invalid IP", "localhos", 9995, "/tmp/db", true},
+		{"port zero", "127.0.0.1", 0, "/tmp/db", true},
+		{"port overflow", "127.0.0.1", 65536, "/tmp/db", true},
+		{"empty dbdir", "127.0.0.1", 9995, "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateRecord(tt.ip, tt.port, tt.dbdir)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateRecord() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateReplay(t *testing.T) {
+	tests := []struct {
+		name    string
+		server  string
+		port    int
+		delay   int
+		dbdir   string
+		workers int
+		wantErr bool
+	}{
+		{"valid", "127.0.0.1", 9995, 100, "/tmp/db", 1, false},
+		{"valid IPv6", "::1", 9995, 100, "/tmp/db", 4, false},
+		{"invalid server IP", "bad", 9995, 100, "/tmp/db", 1, true},
+		{"port zero", "127.0.0.1", 0, 100, "/tmp/db", 1, true},
+		{"delay zero", "127.0.0.1", 9995, 0, "/tmp/db", 1, true},
+		{"delay negative", "127.0.0.1", 9995, -1, "/tmp/db", 1, true},
+		{"workers zero", "127.0.0.1", 9995, 100, "/tmp/db", 0, true},
+		{"workers negative", "127.0.0.1", 9995, 100, "/tmp/db", -1, true},
+		{"empty dbdir", "127.0.0.1", 9995, 100, "", 1, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateReplay(tt.server, tt.port, tt.delay, tt.dbdir, tt.workers)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateReplay() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateBarrage(t *testing.T) {
+	tests := []struct {
+		name             string
+		server           string
+		port             int
+		srcRange         string
+		dstRange         string
+		workers          int
+		delay            int
+		templateInterval int
+		wantErr          bool
+	}{
+		{"valid", "127.0.0.1", 9995, "10.0.0.0/8", "10.0.0.0/8", 4, 100, 30, false},
+		{"valid IPv6 server", "::1", 9995, "::/64", "::/64", 1, 50, 0, false},
+		{"invalid server", "bad", 9995, "10.0.0.0/8", "10.0.0.0/8", 4, 100, 30, true},
+		{"invalid srcRange", "127.0.0.1", 9995, "bad", "10.0.0.0/8", 4, 100, 30, true},
+		{"invalid dstRange", "127.0.0.1", 9995, "10.0.0.0/8", "bad", 4, 100, 30, true},
+		{"workers zero", "127.0.0.1", 9995, "10.0.0.0/8", "10.0.0.0/8", 0, 100, 30, true},
+		{"workers negative", "127.0.0.1", 9995, "10.0.0.0/8", "10.0.0.0/8", -1, 100, 30, true},
+		{"delay zero", "127.0.0.1", 9995, "10.0.0.0/8", "10.0.0.0/8", 4, 0, 30, true},
+		{"delay negative", "127.0.0.1", 9995, "10.0.0.0/8", "10.0.0.0/8", 4, -1, 30, true},
+		{"templateInterval negative", "127.0.0.1", 9995, "10.0.0.0/8", "10.0.0.0/8", 4, 100, -1, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateBarrage(tt.server, tt.port, tt.srcRange, tt.dstRange, tt.workers, tt.delay, tt.templateInterval)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateBarrage() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateProxy(t *testing.T) {
+	tests := []struct {
+		name    string
+		ip      string
+		port    int
+		targets []string
+		wantErr bool
+	}{
+		{"valid", "127.0.0.1", 9995, []string{"127.0.0.1:9996"}, false},
+		{"valid multiple", "127.0.0.1", 9995, []string{"127.0.0.1:9996", "127.0.0.1:9997"}, false},
+		{"invalid listener IP", "bad", 9995, []string{"127.0.0.1:9996"}, true},
+		{"port zero", "127.0.0.1", 0, []string{"127.0.0.1:9996"}, true},
+		{"no targets", "127.0.0.1", 9995, nil, true},
+		{"bad target format", "127.0.0.1", 9995, []string{"bad"}, true},
+		{"bad target port", "127.0.0.1", 9995, []string{"127.0.0.1:0"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateProxy(tt.ip, tt.port, tt.targets)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateProxy() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateWeb(t *testing.T) {
+	tests := []struct {
+		name    string
+		ip      string
+		port    int
+		wantErr bool
+	}{
+		{"valid loopback", "127.0.0.1", 8080, false},
+		{"valid wildcard", "0.0.0.0", 8080, false},
+		{"valid IPv6", "::1", 8080, false},
+		{"invalid IP", "bad", 8080, true},
+		{"port zero", "127.0.0.1", 0, true},
+		{"port overflow", "127.0.0.1", 65536, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateWeb(tt.ip, tt.port)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateWeb() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/spf13/viper v1.21.0
 	golang.org/x/crypto v0.54.0
+	golang.org/x/sync v0.22.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,8 @@ golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
+golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/lifecycle/lifecycle.go
+++ b/lifecycle/lifecycle.go
@@ -46,18 +46,23 @@ func (m *Manager) WaitGroup() *sync.WaitGroup {
 	return m.wg
 }
 
-// SetupSignalHandler registers SIGINT and SIGTERM handlers that call cancel().
-// Returns a cleanup channel that signals when shutdown is complete.
+// SetupSignalHandler registers a one-shot SIGINT/SIGTERM handler that calls
+// Cancel. Cancelling the manager also unregisters the signal notification and
+// stops the handler goroutine.
 func (m *Manager) SetupSignalHandler() <-chan bool {
 	sigChan := make(chan os.Signal, 1)
 	cleanupDone := make(chan bool, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 
 	go func() {
-		for range sigChan {
+		defer signal.Stop(sigChan)
+		defer close(cleanupDone)
+		select {
+		case <-sigChan:
 			log.Printf("\rReceived signal, shutting down...\n\n")
 			m.Cancel()
 			cleanupDone <- true
+		case <-m.ctx.Done():
 		}
 	}()
 	return cleanupDone

--- a/lifecycle/lifecycle_test.go
+++ b/lifecycle/lifecycle_test.go
@@ -246,6 +246,7 @@ func TestWaitGroupConcurrentAccess(t *testing.T) {
 
 func TestSetupSignalHandlerCreatesChannels(t *testing.T) {
 	m := New()
+	defer m.Cancel()
 
 	cleanupDone := m.SetupSignalHandler()
 
@@ -283,6 +284,21 @@ func TestSetupSignalHandlerReceivesSignal(t *testing.T) {
 	// cleanupDone may or may not have a value (depends on whether
 	// a signal was received), but it should exist
 	_ = cleanupDone
+}
+
+func TestSetupSignalHandlerStopsAfterCancel(t *testing.T) {
+	m := New()
+	cleanupDone := m.SetupSignalHandler()
+	m.Cancel()
+
+	select {
+	case _, ok := <-cleanupDone:
+		if ok {
+			t.Fatal("cleanup channel should close without a signal value")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("signal handler did not stop after cancellation")
+	}
 }
 
 func TestContextValuePropagation(t *testing.T) {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -7,9 +7,10 @@ package proxy
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log"
 	"net"
-	"os"
 	"strconv"
 	"sync"
 	"time"
@@ -19,6 +20,7 @@ import (
 	"github.com/dmabry/flowgre/netflow"
 	"github.com/dmabry/flowgre/stats"
 	"github.com/dmabry/flowgre/utils"
+	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -34,14 +36,20 @@ const (
 // Worker is the goroutine used to create workers
 func worker(id int, ctx context.Context, server string, port int, wg *sync.WaitGroup, workerChan <-chan []byte) {
 	defer wg.Done()
+	if err := runWorker(id, ctx, server, port, workerChan); err != nil {
+		log.Printf("Worker [%2d] error: %v", id, err)
+	}
+}
+
+func runWorker(id int, ctx context.Context, server string, port int, workerChan <-chan []byte) error {
 	// Sent limiter to given delay
 	// Configure connection to use.  It looks like a listener, but it will be used to send packet.  Allows me to set the source port
 	srcPort := utils.RandomNum(sourcePortMin, sourcePortMax)
 	conn, err := net.ListenUDP("udp", &net.UDPAddr{Port: srcPort})
 	if err != nil {
-		log.Printf("Listen failed: %v\n", err)
-		return
+		return fmt.Errorf("listen on source port %d: %w", srcPort, err)
 	}
+	defer conn.Close()
 	// Convert given IP String to net.IP type
 	destIP := net.ParseIP(server)
 	log.Printf("Worker [%2d] Sending flows at %s:%d\n",
@@ -51,15 +59,17 @@ func worker(id int, ctx context.Context, server string, port int, wg *sync.WaitG
 		select {
 		case <-ctx.Done(): //Caught the signal to be done.... time to wrap it up
 			log.Printf("Worker [%2d] exiting due to signal\n", id)
-			return
-		case payload := <-workerChan:
+			return nil
+		case payload, ok := <-workerChan:
+			if !ok {
+				return nil
+			}
 			// length := len(payload)
 			//log.Printf("Worker [%2d] sending packet to %s:%d with length: %d\n", id, server, port, length)
 			// send packet here.
 			_, err = utils.SendPacket(conn, &net.UDPAddr{IP: destIP, Port: port}, payload, false)
 			if err != nil {
-				log.Printf("Worker [%2d] Issue sending packet: %v\n", id, err)
-				return
+				return fmt.Errorf("send packet: %w", err)
 			}
 		}
 	}
@@ -68,19 +78,26 @@ func worker(id int, ctx context.Context, server string, port int, wg *sync.WaitG
 // replicator is used to take payloads off the dataChan and pass it to each worker's channel for sending
 func replicator(ctx context.Context, wg *sync.WaitGroup, dataChan <-chan []byte, targets []chan []byte, verbose bool) {
 	defer wg.Done()
+	_ = runReplicator(ctx, dataChan, targets, verbose)
+}
+
+func runReplicator(ctx context.Context, dataChan <-chan []byte, targets []chan []byte, verbose bool) error {
 	for {
 		select {
 		case <-ctx.Done():
 			log.Println("Replicator exiting due to signal")
-			return
-		case payload := <-dataChan:
+			return nil
+		case payload, ok := <-dataChan:
+			if !ok {
+				return nil
+			}
 			for _, target := range targets {
 				select {
 				case target <- payload:
 					// sent successfully
 				case <-ctx.Done():
 					log.Println("Replicator context cancelled during send")
-					return
+					return nil
 				default:
 					// Channel full, drop packet to avoid deadlock
 					if verbose {
@@ -95,38 +112,47 @@ func replicator(ctx context.Context, wg *sync.WaitGroup, dataChan <-chan []byte,
 // proxyListener is used to pull packets off the wire and put the byte payload on the data chan
 func proxyListener(ctx context.Context, wg *sync.WaitGroup, ip string, port int, proxyChan chan<- []byte, verbose bool) {
 	defer wg.Done()
+	if err := runProxyListener(ctx, ip, port, proxyChan, verbose); err != nil {
+		log.Printf("Proxy listener error: %v", err)
+	}
+}
+
+func runProxyListener(ctx context.Context, ip string, port int, proxyChan chan<- []byte, verbose bool) error {
 	// Create UDP listener and setup db to catch files
 	listenIP := net.ParseIP(ip)
 	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: listenIP, Port: port})
 	if err != nil {
-		log.Printf("Listening on %s:%d failed! Got: %v\n", ip, port, err)
-		return
+		return fmt.Errorf("listen on %s:%d: %w", ip, port, err)
 	}
 	log.Printf("Listening on %s:%d", ip, port)
-	defer func(conn *net.UDPConn) {
-		err := conn.Close()
-		if err != nil {
-			log.Printf("Error closing listener: %v\n", err)
-		}
-	}(conn)
+	defer conn.Close()
+	stopCancelWakeup := context.AfterFunc(ctx, func() {
+		_ = conn.SetReadDeadline(time.Now())
+	})
+	defer stopCancelWakeup()
 	// Start the loop and check context for done, otherwise listen for packets
 	for {
 		select {
 		case <-ctx.Done():
 			log.Println("Proxy Listener exiting due to signal")
-			return
+			return nil
 		default:
 			payload := make([]byte, udpMaxBufferSize)
 			timeout := time.Now().Add(5 * time.Second)
 			err := conn.SetReadDeadline(timeout)
 			if err != nil {
-				log.Printf("Issue setting deadline: %v", err)
-				return
+				return fmt.Errorf("set read deadline: %w", err)
 			}
 			length, fromIP, err := conn.ReadFromUDP(payload)
 			if err != nil {
-				// No packets received before deadline moving on ...
-				continue
+				if ctx.Err() != nil {
+					return nil
+				}
+				var netErr net.Error
+				if errors.As(err, &netErr) && netErr.Timeout() {
+					continue
+				}
+				return fmt.Errorf("read UDP packet: %w", err)
 			}
 			payload = payload[:length]
 			if verbose {
@@ -136,7 +162,7 @@ func proxyListener(ctx context.Context, wg *sync.WaitGroup, ip string, port int,
 			select {
 			case proxyChan <- payload:
 			case <-ctx.Done():
-				return
+				return nil
 			default:
 				if verbose {
 					log.Printf("proxyListener: dropped packet (proxyChan full)")
@@ -149,12 +175,18 @@ func proxyListener(ctx context.Context, wg *sync.WaitGroup, ip string, port int,
 // statsPrinter prints out the status every 10 seconds.
 func statsPrinter(ctx context.Context, wg *sync.WaitGroup, rStats *stats.RecordStat) {
 	defer wg.Done()
+	_ = runStatsPrinter(ctx, rStats)
+}
+
+func runStatsPrinter(ctx context.Context, rStats *stats.RecordStat) error {
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			//log.Println("statsPrinter exiting due to signal")
-			return
-		case <-time.After(time.Second * 10):
+			return nil
+		case <-ticker.C:
 			log.Printf("Netflow v9 Packets: %d Ignored Packets: %d ",
 				rStats.LoadValid(), rStats.LoadInvalid())
 		}
@@ -164,6 +196,10 @@ func statsPrinter(ctx context.Context, wg *sync.WaitGroup, rStats *stats.RecordS
 // parseNetflow validates that the payload is valid NetFlow v9 or IPFIX v10 and forwards it.
 func parseNetflow(ctx context.Context, wg *sync.WaitGroup, proxyChan <-chan []byte, dataChan chan<- []byte, rStats *stats.RecordStat, verbose bool) {
 	defer wg.Done()
+	_ = runParseNetflow(ctx, proxyChan, dataChan, rStats, verbose)
+}
+
+func runParseNetflow(ctx context.Context, proxyChan <-chan []byte, dataChan chan<- []byte, rStats *stats.RecordStat, verbose bool) error {
 
 	ticker := time.NewTicker(10 * time.Second)
 	defer ticker.Stop()
@@ -172,14 +208,19 @@ func parseNetflow(ctx context.Context, wg *sync.WaitGroup, proxyChan <-chan []by
 		select {
 		case <-ctx.Done():
 			log.Println("Flow parser exiting due to signal")
-			return
-		case payload := <-proxyChan:
+			return nil
+		case payload, ok := <-proxyChan:
+			if !ok {
+				return nil
+			}
 			ok, err := netflow.IsValidNetFlow(payload, 9)
 			if err != nil {
 				// Try IPFIX
 				ok, err = ipfix.IsValidIPFIX(payload)
 				if err != nil {
-					log.Printf("Skipping packet due to issue parsing: %v", err)
+					if verbose {
+						log.Printf("Skipping packet due to issue parsing: %v", err)
+					}
 				}
 			}
 			if ok {
@@ -188,7 +229,7 @@ func parseNetflow(ctx context.Context, wg *sync.WaitGroup, proxyChan <-chan []by
 				case dataChan <- payload:
 				case <-ctx.Done():
 					log.Println("Flow parser context cancelled during send")
-					return
+					return nil
 				default:
 					if verbose {
 						log.Printf("Flow parser: dropped packet (dataChan full)")
@@ -208,17 +249,27 @@ func parseNetflow(ctx context.Context, wg *sync.WaitGroup, proxyChan <-chan []by
 // It sets up OS signal handling (SIGINT/SIGTERM) for clean shutdown.
 func Run(ip string, port int, verbose bool, targets []string) {
 	mgr := lifecycle.New()
-	ctx := mgr.Context()
-	wg := mgr.WaitGroup()
+	defer mgr.Cancel()
 
 	// Setup signal handling BEFORE starting goroutines to avoid missed signals
-	cleanupDone := mgr.SetupSignalHandler()
-	go func() {
-		<-cleanupDone
-		mgr.Cancel()
-	}()
+	_ = mgr.SetupSignalHandler()
 
-	// Create channels
+	if err := RunCtx(mgr.Context(), ip, port, verbose, targets); err != nil {
+		log.Printf("Proxy error: %v", err)
+	}
+	mgr.Wait()
+}
+
+// RunCtx starts the proxy with an externally managed context and propagates
+// startup and runtime failures from every pipeline component.
+func RunCtx(ctx context.Context, ip string, port int, verbose bool, targets []string) error {
+	if len(targets) == 0 {
+		return fmt.Errorf("at least one target is required")
+	}
+	if len(targets) > maxTargets {
+		return fmt.Errorf("can't have more than %d targets", maxTargets)
+	}
+
 	proxyChan := make(chan []byte, bufferSize)
 	dataChan := make(chan []byte, bufferSize)
 	rStats := stats.RecordStat{
@@ -227,46 +278,46 @@ func Run(ip string, port int, verbose bool, targets []string) {
 	}
 	// Create dedicated channel per target <= maxTargets
 	workers := len(targets)
-	if workers == 0 {
-		log.Fatal("Error: at least one --target is required (format: IP:PORT)")
-	}
-	if workers > maxTargets {
-		log.Printf("Can't have more than %d Targets", maxTargets)
-		os.Exit(1)
-	}
 	workerChans := make([]chan []byte, workers)
-	// start workers
-	wg.Add(workers)
+	type parsedTarget struct {
+		host string
+		port int
+	}
+	parsedTargets := make([]parsedTarget, workers)
 	for w := range workers {
-		id := w + 1
 		workerChan := make(chan []byte, bufferSize)
 		workerChans[w] = workerChan
 		target := targets[w]
 		targetIP, targetPort, err := net.SplitHostPort(target)
 		if err != nil {
-			log.Fatalf("Issue parsing target: %v\n", err)
+			return fmt.Errorf("parse target %q: %w", target, err)
 		}
 		targetPortInt, err := strconv.Atoi(targetPort)
 		if err != nil {
-			log.Fatalf("Issue parsing target port: %v\n", err)
+			return fmt.Errorf("parse target %q port: %w", target, err)
 		}
 		if targetPortInt < 1 || targetPortInt > 65535 {
-			log.Fatalf("Error: target port %d out of valid range (1-65535)", targetPortInt)
+			return fmt.Errorf("target %q port %d out of range 1-65535", target, targetPortInt)
 		}
-		go worker(id, ctx, targetIP, targetPortInt, wg, workerChan)
+		if net.ParseIP(targetIP) == nil {
+			return fmt.Errorf("target %q has invalid IP address %q", target, targetIP)
+		}
+		parsedTargets[w] = parsedTarget{host: targetIP, port: targetPortInt}
 	}
 
-	// Start parseNetflow and replicator first
-	wg.Add(1)
-	go statsPrinter(ctx, wg, &rStats)
-	wg.Add(1)
-	go parseNetflow(ctx, wg, proxyChan, dataChan, &rStats, verbose)
-	wg.Add(1)
-	go replicator(ctx, wg, dataChan, workerChans, verbose)
+	eg, egCtx := errgroup.WithContext(ctx)
+	for w, target := range parsedTargets {
+		id := w + 1
+		workerChan := workerChans[w]
+		eg.Go(func() error { return runWorker(id, egCtx, target.host, target.port, workerChan) })
+	}
+	eg.Go(func() error { return runStatsPrinter(egCtx, &rStats) })
+	eg.Go(func() error { return runParseNetflow(egCtx, proxyChan, dataChan, &rStats, verbose) })
+	eg.Go(func() error { return runReplicator(egCtx, dataChan, workerChans, verbose) })
+	eg.Go(func() error { return runProxyListener(egCtx, ip, port, proxyChan, verbose) })
 
-	// Finally, start up proxyListener
-	wg.Add(1)
-	go proxyListener(ctx, wg, ip, port, proxyChan, verbose)
-
-	mgr.Wait()
+	if err := eg.Wait(); err != nil {
+		return fmt.Errorf("proxy: %w", err)
+	}
+	return nil
 }

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -549,6 +550,23 @@ func TestTargetValidation(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestRunCtxReturnsListenerError(t *testing.T) {
+	blocker, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatalf("reserve listener port: %v", err)
+	}
+	defer blocker.Close()
+
+	port := blocker.LocalAddr().(*net.UDPAddr).Port
+	err = RunCtx(context.Background(), "127.0.0.1", port, false, []string{"127.0.0.1:9995"})
+	if err == nil {
+		t.Fatal("expected listener error")
+	}
+	if !strings.Contains(err.Error(), "listen on") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/record/record.go
+++ b/record/record.go
@@ -8,6 +8,8 @@ package record
 import (
 	"context"
 	"encoding/binary"
+	"errors"
+	"fmt"
 	"log"
 	"net"
 	"sync"
@@ -18,6 +20,7 @@ import (
 	"github.com/dmabry/flowgre/lifecycle"
 	"github.com/dmabry/flowgre/netflow"
 	"github.com/dmabry/flowgre/stats"
+	"golang.org/x/sync/errgroup"
 )
 
 const udpMaxBufferSize = 65507
@@ -25,38 +28,47 @@ const udpMaxBufferSize = 65507
 // netIngest is used to pull packets off the wire and put the byte payload on the data chan
 func netIngest(ctx context.Context, wg *sync.WaitGroup, ip string, port int, data chan<- []byte, verbose bool) {
 	defer wg.Done()
+	if err := runNetIngest(ctx, ip, port, data, verbose); err != nil {
+		log.Printf("Packet ingest error: %v", err)
+	}
+}
+
+func runNetIngest(ctx context.Context, ip string, port int, data chan<- []byte, verbose bool) error {
 	// Create UDP listener and setup db to catch files
 	listenIP := net.ParseIP(ip)
 	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: listenIP, Port: port})
 	if err != nil {
-		log.Printf("Listening on %s:%d failed! Got: %v\n", ip, port, err)
-		return
+		return fmt.Errorf("listen on %s:%d: %w", ip, port, err)
 	}
 	log.Printf("Listening on %s:%d", ip, port)
-	defer func(conn *net.UDPConn) {
-		err := conn.Close()
-		if err != nil {
-			log.Printf("Error closing listener: %v", err)
-		}
-	}(conn)
+	defer conn.Close()
+	stopCancelWakeup := context.AfterFunc(ctx, func() {
+		_ = conn.SetReadDeadline(time.Now())
+	})
+	defer stopCancelWakeup()
 	// Start the loop and check context for done, otherwise listen for packets
 	for {
 		select {
 		case <-ctx.Done():
 			log.Println("Packet ingest exiting due to signal")
-			return
+			return nil
 		default:
 			payload := make([]byte, udpMaxBufferSize)
 			timeout := time.Now().Add(5 * time.Second)
 			err := conn.SetReadDeadline(timeout)
 			if err != nil {
-				log.Printf("Issue setting deadline: %v", err)
-				return
+				return fmt.Errorf("set read deadline: %w", err)
 			}
 			length, fromIP, err := conn.ReadFromUDP(payload)
 			if err != nil {
-				// No packets received before deadline moving on ...
-				continue
+				if ctx.Err() != nil {
+					return nil
+				}
+				var netErr net.Error
+				if errors.As(err, &netErr) && netErr.Timeout() {
+					continue
+				}
+				return fmt.Errorf("read UDP packet: %w", err)
 			}
 			payload = payload[:length]
 			if verbose {
@@ -66,7 +78,7 @@ func netIngest(ctx context.Context, wg *sync.WaitGroup, ip string, port int, dat
 			select {
 			case data <- payload:
 			case <-ctx.Done():
-				return
+				return nil
 			}
 		}
 	}
@@ -75,42 +87,83 @@ func netIngest(ctx context.Context, wg *sync.WaitGroup, ip string, port int, dat
 // dbIngest pulls byte payload off the data chan and puts them in the badger db
 func dbIngest(ctx context.Context, wg *sync.WaitGroup, dbdir string, data <-chan []byte, verbose bool) {
 	defer wg.Done()
+	if err := runDBIngest(ctx, dbdir, data, verbose); err != nil {
+		log.Printf("Database ingest error: %v", err)
+	}
+}
+
+func nextRecordID(db *badger.DB) (uint32, error) {
+	var next uint32 = 1
+	err := db.View(func(txn *badger.Txn) error {
+		opts := badger.DefaultIteratorOptions
+		opts.Reverse = true
+		opts.PrefetchValues = false
+		it := txn.NewIterator(opts)
+		defer it.Close()
+
+		for it.Rewind(); it.Valid(); it.Next() {
+			key := it.Item().Key()
+			if len(key) != 4 {
+				continue
+			}
+			last := binary.BigEndian.Uint32(key)
+			if last == ^uint32(0) {
+				return fmt.Errorf("record database key space exhausted")
+			}
+			next = last + 1
+			break
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, fmt.Errorf("find last record key: %w", err)
+	}
+	return next, nil
+}
+
+func runDBIngest(ctx context.Context, dbdir string, data <-chan []byte, verbose bool) (retErr error) {
 	// Create/Open DB for writing
 	options := badger.DefaultOptions(dbdir)
 	// Disable badger logging output
 	options.Logger = nil
 	db, err := badger.Open(options)
 	if err != nil {
-		log.Printf("Failed to open DB: %v\n", err)
-		return
+		return fmt.Errorf("open database %s: %w", dbdir, err)
 	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			retErr = errors.Join(retErr, fmt.Errorf("close database: %w", err))
+		}
+	}()
 	log.Printf("Writing to database %s\n", dbdir)
-	// Prep the loop
-	var count uint32 = 0
+	nextID, err := nextRecordID(db)
+	if err != nil {
+		return err
+	}
 	// Start the loop
 	for {
 		// Check to see if context is done and return, otherwise pull payloads and write
 		select {
 		case <-ctx.Done():
 			log.Println("Database ingest exiting due to signal")
-			err := db.Close()
-			if err != nil {
-				log.Printf("Issue closing database: %v", err)
-				return
+			return nil
+		case payload, ok := <-data:
+			if !ok {
+				return nil
 			}
-			return
-		case payload := <-data:
-			count++
 			key := make([]byte, 4)
-			binary.BigEndian.PutUint32(key, count)
+			binary.BigEndian.PutUint32(key, nextID)
 			err := db.Update(func(txn *badger.Txn) error {
 				entry := badger.NewEntry(key, payload)
-				terr := txn.SetEntry(entry)
-				return terr
+				return txn.SetEntry(entry)
 			})
 			if err != nil {
-				log.Printf("Error writing to db: %v\n", err)
+				return fmt.Errorf("write record %d: %w", nextID, err)
 			}
+			if nextID == ^uint32(0) {
+				return fmt.Errorf("record database key space exhausted")
+			}
+			nextID++
 		}
 	}
 }
@@ -118,6 +171,10 @@ func dbIngest(ctx context.Context, wg *sync.WaitGroup, dbdir string, data <-chan
 // parseFlow validates that the payload received is valid NetFlow v9 or IPFIX v10
 func parseFlow(ctx context.Context, wg *sync.WaitGroup, parseChan <-chan []byte, dataChan chan<- []byte, verbose bool) {
 	defer wg.Done()
+	_ = runParseFlow(ctx, parseChan, dataChan, verbose)
+}
+
+func runParseFlow(ctx context.Context, parseChan <-chan []byte, dataChan chan<- []byte, verbose bool) error {
 	// Prep the loop
 	rStats := stats.RecordStat{
 		ValidCount:   0,
@@ -130,15 +187,21 @@ func parseFlow(ctx context.Context, wg *sync.WaitGroup, parseChan <-chan []byte,
 		select {
 		case <-ctx.Done():
 			log.Println("Flow parser exiting due to signal")
-			return
-		case payload := <-parseChan:
+			return nil
+		case payload, ok := <-parseChan:
+			if !ok {
+				return nil
+			}
 			// Decode first uint16 and see if it is a version 9 (NetFlow) or 10 (IPFIX)
 			ok, err := netflow.IsValidNetFlow(payload, 9)
 			if err != nil {
 				// Try IPFIX
 				ok, err = ipfix.IsValidIPFIX(payload)
 				if err != nil {
-					log.Printf("Skipping packet due to issue parsing: %v", err)
+					if verbose {
+						log.Printf("Skipping packet due to issue parsing: %v", err)
+					}
+					rStats.IncrInvalid()
 					continue
 				}
 			}
@@ -148,7 +211,7 @@ func parseFlow(ctx context.Context, wg *sync.WaitGroup, parseChan <-chan []byte,
 				select {
 				case dataChan <- payload:
 				case <-ctx.Done():
-					return
+					return nil
 				}
 			} else {
 				// Not a valid flow Packet... skip
@@ -164,25 +227,18 @@ func parseFlow(ctx context.Context, wg *sync.WaitGroup, parseChan <-chan []byte,
 // RunCtx starts the recording process with an external context.
 // Cancelling ctx stops all workers cleanly. Use Run() for CLI usage
 // where OS signal handling is desired.
-func RunCtx(ctx context.Context, ip string, port int, dbdir string, verbose bool) {
-	wg := &sync.WaitGroup{}
+func RunCtx(ctx context.Context, ip string, port int, dbdir string, verbose bool) error {
 	dataChan := make(chan []byte, 1024)
 	parseChan := make(chan []byte, 1024)
+	eg, egCtx := errgroup.WithContext(ctx)
 
-	// Start netIngest
-	wg.Add(1)
-	go netIngest(ctx, wg, ip, port, parseChan, verbose)
-
-	// Start parseFlow
-	wg.Add(1)
-	go parseFlow(ctx, wg, parseChan, dataChan, verbose)
-
-	// Start dbIngest
-	wg.Add(1)
-	go dbIngest(ctx, wg, dbdir, dataChan, verbose)
-
-	// Wait for all goroutines to finish
-	wg.Wait()
+	eg.Go(func() error { return runNetIngest(egCtx, ip, port, parseChan, verbose) })
+	eg.Go(func() error { return runParseFlow(egCtx, parseChan, dataChan, verbose) })
+	eg.Go(func() error { return runDBIngest(egCtx, dbdir, dataChan, verbose) })
+	if err := eg.Wait(); err != nil {
+		return fmt.Errorf("record: %w", err)
+	}
+	return nil
 }
 
 // Run Record. Kicks off the recording process.
@@ -190,12 +246,14 @@ func RunCtx(ctx context.Context, ip string, port int, dbdir string, verbose bool
 // Use RunCtx() when you need to control the lifecycle via context.
 func Run(ip string, port int, dbdir string, verbose bool) {
 	mgr := lifecycle.New()
+	defer mgr.Cancel()
 
 	// Setup signal handling BEFORE starting workers to avoid race
-	cleanupDone := mgr.SetupSignalHandler()
+	_ = mgr.SetupSignalHandler()
 
-	RunCtx(mgr.Context(), ip, port, dbdir, verbose)
+	if err := RunCtx(mgr.Context(), ip, port, dbdir, verbose); err != nil {
+		log.Printf("Record error: %v", err)
+	}
 
-	<-cleanupDone
 	mgr.Wait()
 }

--- a/record/record_test.go
+++ b/record/record_test.go
@@ -9,10 +9,12 @@ import (
 	"encoding/binary"
 	"net"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	badger "github.com/dgraph-io/badger/v3"
 	"github.com/dmabry/flowgre/netflow"
 )
 
@@ -179,16 +181,16 @@ func TestParseFlow_MalformedNetFlow(t *testing.T) {
 
 	// Build a packet with a valid v9 header but a FlowSet with reserved ID (2)
 	var buf bytes.Buffer
-	binary.Write(&buf, binary.BigEndian, uint16(9))   // version
-	binary.Write(&buf, binary.BigEndian, uint16(1))   // flowCount
-	binary.Write(&buf, binary.BigEndian, uint32(1000)) // SysUptime
+	binary.Write(&buf, binary.BigEndian, uint16(9))       // version
+	binary.Write(&buf, binary.BigEndian, uint16(1))       // flowCount
+	binary.Write(&buf, binary.BigEndian, uint32(1000))    // SysUptime
 	binary.Write(&buf, binary.BigEndian, uint32(1000000)) // UnixSec
-	binary.Write(&buf, binary.BigEndian, uint32(1))    // FlowSequence
-	binary.Write(&buf, binary.BigEndian, uint32(618))  // SourceID
+	binary.Write(&buf, binary.BigEndian, uint32(1))       // FlowSequence
+	binary.Write(&buf, binary.BigEndian, uint32(618))     // SourceID
 	// Reserved FlowSet ID 2 (must be rejected)
-	binary.Write(&buf, binary.BigEndian, uint16(2))    // FlowSetID (reserved)
-	binary.Write(&buf, binary.BigEndian, uint16(8))    // Length
-	binary.Write(&buf, binary.BigEndian, uint32(0))    // padding
+	binary.Write(&buf, binary.BigEndian, uint16(2)) // FlowSetID (reserved)
+	binary.Write(&buf, binary.BigEndian, uint16(8)) // Length
+	binary.Write(&buf, binary.BigEndian, uint32(0)) // padding
 
 	malformed := buf.Bytes()
 	valid, _ := netflow.IsValidNetFlow(malformed, 9)
@@ -379,4 +381,46 @@ func TestDbIngestContextCancellation(t *testing.T) {
 	}
 
 	close(dataChan)
+}
+
+func TestRunCtxReturnsListenerError(t *testing.T) {
+	blocker, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatalf("reserve listener port: %v", err)
+	}
+	defer blocker.Close()
+
+	port := blocker.LocalAddr().(*net.UDPAddr).Port
+	err = RunCtx(context.Background(), "127.0.0.1", port, t.TempDir(), false)
+	if err == nil {
+		t.Fatal("expected listener error")
+	}
+	if !strings.Contains(err.Error(), "listen on") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNextRecordIDAppendsAfterExistingRecords(t *testing.T) {
+	opts := badger.DefaultOptions(t.TempDir()).WithLogger(nil)
+	db, err := badger.Open(opts)
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	defer db.Close()
+
+	key := make([]byte, 4)
+	binary.BigEndian.PutUint32(key, 7)
+	if err := db.Update(func(txn *badger.Txn) error {
+		return txn.Set(key, []byte("existing"))
+	}); err != nil {
+		t.Fatalf("seed database: %v", err)
+	}
+
+	next, err := nextRecordID(db)
+	if err != nil {
+		t.Fatalf("next record ID: %v", err)
+	}
+	if next != 8 {
+		t.Fatalf("next record ID = %d, want 8", next)
+	}
 }

--- a/replay/replay.go
+++ b/replay/replay.go
@@ -7,156 +7,193 @@ package replay
 
 import (
 	"context"
+	"encoding/binary"
+	"fmt"
 	"log"
 	"net"
 	"runtime"
-	"sync"
 	"time"
 
 	badger "github.com/dgraph-io/badger/v3"
+	"github.com/dmabry/flowgre/ipfix"
 	"github.com/dmabry/flowgre/lifecycle"
 	"github.com/dmabry/flowgre/netflow"
 	"github.com/dmabry/flowgre/utils"
+	"golang.org/x/sync/errgroup"
 )
 
+// netflowVersion returns the version field from a flow packet header.
+// Returns 0 if the payload is too short.
+func netflowVersion(payload []byte) uint16 {
+	if len(payload) < 2 {
+		return 0
+	}
+	return binary.BigEndian.Uint16(payload[0:2])
+}
+
+// updateTimestamp updates the timestamp in a flow packet, dispatching to the
+// correct protocol-specific updater based on the version field.
+func updateTimestamp(payload []byte) ([]byte, error) {
+	version := netflowVersion(payload)
+	switch version {
+	case 9:
+		return netflow.UpdateTimeStamp(payload)
+	case 10:
+		return ipfix.UpdateTimeStamp(payload)
+	default:
+		return nil, fmt.Errorf("unsupported flow version %d for timestamp update", version)
+	}
+}
+
 // Worker is the goroutine used to create workers
-func worker(id int, ctx context.Context, server string, port int, delay int, wg *sync.WaitGroup, loop bool, dataChan <-chan []byte) {
-	defer wg.Done()
-	// Sent limiter to given delay
+func worker(id int, ctx context.Context, server string, port int, delay int, loop bool, dataChan <-chan []byte) error {
 	limiter := time.NewTicker(time.Millisecond * time.Duration(delay))
 	defer limiter.Stop()
-	// Configure connection to use.  It looks like a listener, but it will be used to send packet.  Allows me to set the source port
+
 	srcPort := utils.RandomNum(10000, 15000)
 	conn, err := net.ListenUDP("udp", &net.UDPAddr{Port: srcPort})
 	if err != nil {
-		log.Printf("Listen: %v\n", err)
-		return
+		return fmt.Errorf("replay worker %d listen: %w", id, err)
 	}
 	defer conn.Close()
-	// Convert given IP String to net.IP type
-	destIP := net.ParseIP(server)
 
+	destIP := net.ParseIP(server)
 	log.Printf("Worker [%2d] Slinging packets at %s:%d with delay of %dms \n",
 		id, server, port, delay)
-	//Infinite loop to keep slinging until we receive context done.
+
 	for {
 		select {
-		case <-ctx.Done(): //Caught the signal to be done.... time to wrap it up
+		case <-ctx.Done():
 			log.Printf("Worker [%2d] Exiting due to signal\n", id)
-			return
-		case payload := <-dataChan:
+			return nil
+		case payload, ok := <-dataChan:
+			if !ok {
+				log.Printf("Worker [%2d] Exiting due to closed channel\n", id)
+				return nil
+			}
 			length := len(payload)
 			log.Printf("Worker [%2d] sending packet with length: %d\n", id, length)
-			// send packet here.
 			_, err = utils.SendPacket(conn, &net.UDPAddr{IP: destIP, Port: port}, payload, false)
 			if err != nil {
-				log.Printf("Worker [%2d] Issue sending packet: %v\n", id, err)
-				return
+				return fmt.Errorf("replay worker %d send: %w", id, err)
 			}
-			<-limiter.C
-		case <-time.After(time.Second * 1):
-			if !loop {
-				log.Printf("Worker [%2d] Exiting due to empty channel\n", id)
-				return
+			select {
+			case <-limiter.C:
+			case <-ctx.Done():
+				return nil
 			}
 		}
 	}
 }
 
-// dbReader pulls byte payload out of the database and puts it on the data chan
-func dbReader(ctx context.Context, wg *sync.WaitGroup, dbdir string, dataChan chan<- []byte, loop bool, updateTS bool, verbose bool) {
-	defer wg.Done()
-	// Create/Open DB for reading
+// dbReader pulls byte payload out of the database and puts it on the data chan.
+// In non-loop mode, it closes dataChan after the final pass to signal workers.
+func dbReader(ctx context.Context, dbdir string, dataChan chan<- []byte, loop bool, updateTS bool, verbose bool) error {
+	if !loop {
+		defer close(dataChan)
+	}
+
 	options := badger.DefaultOptions(dbdir)
-	// Disable badger logging output
 	options.Logger = nil
 	db, err := badger.Open(options)
 	if err != nil {
-		log.Printf("Failed to open DB: %v\n", err)
-		return
+		return fmt.Errorf("open DB %s: %w", dbdir, err)
 	}
 	defer db.Close()
 	log.Printf("Reading from database %s\n", dbdir)
-	// Prep the loop
+
 	count := 0
 	itOptions := badger.DefaultIteratorOptions
 	itOptions.PrefetchSize = runtime.GOMAXPROCS(0)
 	for {
+		recordsThisPass := 0
 		select {
 		case <-ctx.Done():
 			log.Println("DB Reader exiting due to signal")
-			return
+			return nil
 		default:
 			err = db.View(func(txn *badger.Txn) error {
 				it := txn.NewIterator(itOptions)
 				defer it.Close()
 				for it.Rewind(); it.Valid(); it.Next() {
-					// Check to see if context is done and return, otherwise pull payloads and write
 					select {
 					case <-ctx.Done():
 						log.Println("DB Reader exiting due to signal, finishing read")
 						return nil
 					default:
 						item := it.Item()
-						//key := item.Key()
-						value, err := item.ValueCopy(nil)
-						if err != nil {
-							log.Printf("DB Reader issue getting value from db: %v", err)
-							return err
+						value, verr := item.ValueCopy(nil)
+						if verr != nil {
+							return fmt.Errorf("read value: %w", verr)
 						}
 						if updateTS {
-							newValue, err := netflow.UpdateTimeStamp(value)
-							if err != nil {
-								log.Printf("DB Reader issue rewriting timestamp: %v", err)
-								return err
+							newValue, verr := updateTimestamp(value)
+							if verr != nil {
+								return fmt.Errorf("update timestamp: %w", verr)
 							}
 							value = newValue
 						}
-						dataChan <- value
+						select {
+						case dataChan <- value:
+						case <-ctx.Done():
+							return nil
+						}
 						count++
+						recordsThisPass++
 					}
 				}
 				return nil
 			})
 			if err != nil {
-				log.Printf("DB Reader had an issue: %v", err)
+				return fmt.Errorf("DB view: %w", err)
 			}
 		}
-		// only run once if not a loop
 		if !loop {
 			break
 		}
+		if recordsThisPass == 0 {
+			timer := time.NewTimer(100 * time.Millisecond)
+			select {
+			case <-ctx.Done():
+				if !timer.Stop() {
+					<-timer.C
+				}
+				return nil
+			case <-timer.C:
+			}
+		}
 	}
 	log.Printf("DB Reader read %d payloads from the database\n", count)
-	log.Printf("DB Reader done.")
-	return
+	return nil
 }
 
 // RunCtx replays netflow packets from a db with an external context.
 // Cancelling ctx stops all workers cleanly. In non-loop mode, the function
 // returns when all packets have been sent. Use Run() for CLI usage where
 // OS signal handling is desired.
-func RunCtx(ctx context.Context, server string, port int, delay int, dbdir string, loop bool, workers int, updateTS bool, verbose bool) {
-	wg := &sync.WaitGroup{}
+func RunCtx(ctx context.Context, server string, port int, delay int, dbdir string, loop bool, workers int, updateTS bool, verbose bool) error {
 	dataChan := make(chan []byte, 1024)
 
-	// Start dbReader
-	wg.Add(1)
-	go dbReader(ctx, wg, dbdir, dataChan, loop, updateTS, verbose)
+	eg, egCtx := errgroup.WithContext(ctx)
 
-	// Start up the workers
-	wg.Add(workers)
+	eg.Go(func() error {
+		return dbReader(egCtx, dbdir, dataChan, loop, updateTS, verbose)
+	})
+
 	for w := 1; w <= workers; w++ {
-		go worker(w, ctx, server, port, delay, wg, loop, dataChan)
+		eg.Go(func() error {
+			return worker(w, egCtx, server, port, delay, loop, dataChan)
+		})
 	}
 
-	// Wait for all goroutines to finish
-	wg.Wait()
+	if err := eg.Wait(); err != nil {
+		return fmt.Errorf("replay: %w", err)
+	}
 
-	// Log completion if context was not cancelled (natural completion)
 	if ctx.Err() == nil {
 		log.Printf("\nReplay complete, shutting down...\n")
 	}
+	return nil
 }
 
 // Run Replay. Kicks off the replay of netflow packets from a db.
@@ -164,16 +201,11 @@ func RunCtx(ctx context.Context, server string, port int, delay int, dbdir strin
 // Use RunCtx() when you need to control the lifecycle via context.
 func Run(server string, port int, delay int, dbdir string, loop bool, workers int, updateTS bool, verbose bool) {
 	mgr := lifecycle.New()
+	defer mgr.Cancel()
 
-	// Setup signal handling via lifecycle manager.
-	cleanupDone := mgr.SetupSignalHandler()
+	_ = mgr.SetupSignalHandler()
 
-	go func() {
-		<-cleanupDone
-		log.Printf("\rReceived signal, shutting down...\n\n")
-		mgr.Cancel()
-	}()
-
-	RunCtx(mgr.Context(), server, port, delay, dbdir, loop, workers, updateTS, verbose)
-	mgr.Wait()
+	if err := RunCtx(mgr.Context(), server, port, delay, dbdir, loop, workers, updateTS, verbose); err != nil {
+		log.Printf("Replay error: %v", err)
+	}
 }

--- a/replay/replay_test.go
+++ b/replay/replay_test.go
@@ -6,13 +6,14 @@ package replay
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"net"
 	"os"
-	"sync"
 	"testing"
 	"time"
 
 	badger "github.com/dgraph-io/badger/v3"
+	"github.com/dmabry/flowgre/ipfix"
 	"github.com/dmabry/flowgre/netflow"
 	"github.com/dmabry/flowgre/utils"
 )
@@ -24,7 +25,6 @@ func TestWorker(t *testing.T) {
 
 	dataChan := make(chan []byte, 1024)
 	receiverReady := make(chan struct{})
-	var wg sync.WaitGroup
 
 	// Bind to port 0 to get a free port
 	probe, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
@@ -36,9 +36,7 @@ func TestWorker(t *testing.T) {
 
 	// Start a receiver on the target port
 	received := make(chan struct{}, 1)
-	wg.Add(1)
 	go func() {
-		defer wg.Done()
 		conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: port})
 		if err != nil {
 			t.Errorf("Failed to listen: %v", err)
@@ -66,8 +64,11 @@ func TestWorker(t *testing.T) {
 	<-receiverReady
 
 	// Start worker
-	wg.Add(1)
-	go worker(1, ctx, "127.0.0.1", port, 100, &wg, false, dataChan)
+	done := make(chan struct{})
+	go func() {
+		worker(1, ctx, "127.0.0.1", port, 100, false, dataChan)
+		close(done)
+	}()
 
 	// Send test payload
 	dataChan <- []byte("worker test")
@@ -83,7 +84,7 @@ func TestWorker(t *testing.T) {
 	// Cleanup
 	cancel()
 	close(dataChan)
-	wg.Wait()
+	<-done
 }
 
 // TestDbReader tests that the database reader can read payloads from BadgerDB.
@@ -116,9 +117,11 @@ func TestDbReader(t *testing.T) {
 	db.Close()
 
 	// Now read from the DB
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go dbReader(ctx, &wg, tmpDir, dataChan, false, false, false)
+	done := make(chan struct{})
+	go func() {
+		dbReader(ctx, tmpDir, dataChan, false, false, false)
+		close(done)
+	}()
 
 	// Wait for data to be read
 	select {
@@ -132,15 +135,37 @@ func TestDbReader(t *testing.T) {
 
 	// Cleanup
 	cancel()
-	wg.Wait()
-	close(dataChan)
+	<-done
+	// dataChan is closed by dbReader in non-loop mode
 }
 
 // TestDbReaderContextCancellation tests that dbReader responds to context cancellation.
-// Note: This test is skipped due to timing issues with BadgerDB iterator.
 func TestDbReaderContextCancellation(t *testing.T) {
 	t.Parallel()
-	t.Skip("Skipping due to timing issues with BadgerDB iterator in test environment")
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	tmpDir := t.TempDir()
+	dataChan := make(chan []byte, 1024)
+
+	done := make(chan struct{})
+	go func() {
+		dbReader(ctx, tmpDir, dataChan, false, false, false)
+		close(done)
+	}()
+
+	// Cancel context
+	cancel()
+
+	// Wait for goroutine to exit
+	select {
+	case <-done:
+		// Good, goroutine exited
+	case <-time.After(5 * time.Second):
+		t.Error("Timeout waiting for goroutine to exit")
+	}
+
+	// dataChan is closed by dbReader in non-loop mode, so don't close it again
 }
 
 // TestWorkerContextCancellation tests that worker responds to context cancellation.
@@ -150,7 +175,6 @@ func TestWorkerContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	dataChan := make(chan []byte, 1024)
-	var wg sync.WaitGroup
 
 	// Bind to port 0 to get a free port
 	probe, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
@@ -161,19 +185,16 @@ func TestWorkerContextCancellation(t *testing.T) {
 	probe.Close()
 
 	// Start worker
-	wg.Add(1)
-	go worker(1, ctx, "127.0.0.1", port, 100, &wg, false, dataChan)
+	done := make(chan struct{})
+	go func() {
+		worker(1, ctx, "127.0.0.1", port, 100, false, dataChan)
+		close(done)
+	}()
 
 	// Cancel context
 	cancel()
 
 	// Wait for goroutine to exit
-	done := make(chan struct{})
-	go func() {
-		wg.Wait()
-		close(done)
-	}()
-
 	select {
 	case <-done:
 		// Good, goroutine exited
@@ -182,6 +203,29 @@ func TestWorkerContextCancellation(t *testing.T) {
 	}
 
 	close(dataChan)
+}
+
+func TestWorkerCancellationInterruptsRateLimitWait(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	dataChan := make(chan []byte, 1)
+	dataChan <- []byte("payload")
+
+	done := make(chan error, 1)
+	go func() {
+		done <- worker(1, ctx, "127.0.0.1", 9995, 10_000, false, dataChan)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("worker returned error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("worker did not interrupt rate limit wait after cancellation")
+	}
 }
 
 // TestRunIntegration tests the full replay flow.
@@ -225,10 +269,7 @@ func TestRunIntegration(t *testing.T) {
 
 	// Start a receiver on target port
 	received := make(chan struct{}, 1)
-	var wg sync.WaitGroup
-	wg.Add(1)
 	go func() {
-		defer wg.Done()
 		conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: port})
 		if err != nil {
 			t.Errorf("Failed to listen: %v", err)
@@ -270,7 +311,6 @@ func TestSendPacket(t *testing.T) {
 	// Start a receiver
 	received := make(chan []byte, 1)
 	receiverReady := make(chan struct{})
-	var wg sync.WaitGroup
 
 	// Bind to port 0 to get a free port
 	probe, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
@@ -280,9 +320,7 @@ func TestSendPacket(t *testing.T) {
 	port := probe.LocalAddr().(*net.UDPAddr).Port
 	probe.Close()
 
-	wg.Add(1)
 	go func() {
-		defer wg.Done()
 		conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: port})
 		if err != nil {
 			t.Errorf("Failed to listen: %v", err)
@@ -329,6 +367,65 @@ func TestSendPacket(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Error("Timeout waiting for receiver")
 	}
+}
 
-	wg.Wait()
+// TestUpdateTimestampNetFlow tests that updateTimestamp correctly updates NetFlow v9 timestamps.
+func TestUpdateTimestampNetFlow(t *testing.T) {
+	t.Parallel()
+
+	session := netflow.NewSession()
+	flow := netflow.GenerateTemplateNetflow(100, session)
+	buf := flow.ToBytes()
+	payload := buf.Bytes()
+
+	before := uint32(time.Now().Unix())
+	result, err := updateTimestamp(payload)
+	if err != nil {
+		t.Fatalf("updateTimestamp failed: %v", err)
+	}
+	after := uint32(time.Now().Unix())
+
+	// Verify the timestamp was updated (bytes 8-11 for NetFlow v9)
+	newTS := binary.BigEndian.Uint32(result[8:12])
+	if newTS < before || newTS > after {
+		t.Errorf("NetFlow timestamp not updated: got %d, expected in [%d, %d]", newTS, before, after)
+	}
+
+	// Verify other fields preserved
+	if binary.BigEndian.Uint16(result[0:2]) != 9 {
+		t.Error("Version field corrupted")
+	}
+}
+
+// TestUpdateTimestampIPFIX tests that updateTimestamp correctly updates IPFIX timestamps.
+func TestUpdateTimestampIPFIX(t *testing.T) {
+	t.Parallel()
+
+	seq := ipfix.NewIPFIXSequence()
+	ipfixPkt := ipfix.GenerateTemplateIPFIX(100, seq)
+	payload, err := ipfixPkt.ToBytes()
+	if err != nil {
+		t.Fatalf("ToBytes failed: %v", err)
+	}
+	payloadBytes := payload.Bytes()
+
+	before := uint32(time.Now().Unix())
+	result, err := updateTimestamp(payloadBytes)
+	if err != nil {
+		t.Fatalf("updateTimestamp failed: %v", err)
+	}
+	after := uint32(time.Now().Unix())
+
+	// Verify the Export Time was updated (bytes 4-7 for IPFIX)
+	newTS := binary.BigEndian.Uint32(result[4:8])
+	if newTS < before || newTS > after {
+		t.Errorf("IPFIX Export Time not updated: got %d, expected in [%d, %d]", newTS, before, after)
+	}
+
+	// Verify Sequence Number preserved (bytes 8-11)
+	origSeqNum := binary.BigEndian.Uint32(payloadBytes[8:12])
+	newSeqNum := binary.BigEndian.Uint32(result[8:12])
+	if origSeqNum != newSeqNum {
+		t.Errorf("IPFIX Sequence Number corrupted: got %d, want %d", newSeqNum, origSeqNum)
+	}
 }

--- a/single/single.go
+++ b/single/single.go
@@ -98,14 +98,10 @@ func RunCtx(ctx context.Context, collectorIP string, destPort int, srcPort int, 
 // shutdown. Use RunCtx() when you need to control the lifecycle via context.
 func Run(collectorIP string, destPort int, srcPort int, count int, srcRange string, dstRange string, hexDump bool) {
 	mgr := lifecycle.New()
+	defer mgr.Cancel()
 
 	// Setup signal handling via lifecycle manager
-	cleanupDone := mgr.SetupSignalHandler()
-	go func() {
-		<-cleanupDone
-		log.Printf("Received signal, shutting down...\n")
-		mgr.Cancel()
-	}()
+	_ = mgr.SetupSignalHandler()
 
 	if err := RunCtx(mgr.Context(), collectorIP, destPort, srcPort, count, srcRange, dstRange, hexDump); err != nil {
 		fmt.Fprintf(os.Stderr, "single error: %v\n", err)

--- a/web/templates/dashboard.go
+++ b/web/templates/dashboard.go
@@ -13,8 +13,8 @@ const DashboardTpl = `
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Raleway">
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontawesome/free@6.5.1/css/all.min.css" integrity="sha384-+0mG0CSBW8WrlbJ3FlRuG4Wp7Io7d9p8rQ75XrVZtP3vM8cBfZz8Y8Y8Y8Y8Y8Y8" crossorigin="anonymous">
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js" integrity="sha384-HgyBrqJxjRUZOv6HlKBv1z2zhzYIhqBvmdgynJ1C5ovwUhVzoC7pGFCjw5F7m1x0" crossorigin="anonymous"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.1/css/all.min.css" integrity="sha384-t1nt8BQoYMLFN5p42tRAtuAAFQaCQODekUVeKKZrEnEyp4H2R0RHFz0KWpmj7i8g" crossorigin="anonymous">
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js" integrity="sha384-e6nUZLBkQ86NJ6TVVKAeSaK8jWa3NhkYWZFomE39AvDbQWeie9PlQqM3pmYW5d1g" crossorigin="anonymous"></script>
 <style>
 :root {
   --bg-primary: #1a1a2e;

--- a/web/web.go
+++ b/web/web.go
@@ -9,12 +9,15 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/subtle"
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log"
 	"math/big"
+	"net"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -91,11 +94,58 @@ func constantTimeCompare(a, b string) bool {
 	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
 }
 
+// isLoopback returns true if the IP is a loopback address (127.0.0.1, ::1).
+// Wildcard addresses (0.0.0.0, ::) are NOT considered loopback.
+func isLoopback(ip string) bool {
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return false
+	}
+	return parsed.IsLoopback()
+}
+
+// ValidateWebBinding checks that the web server binding is safe.
+// Non-loopback addresses require TLS certificate and key files.
+func ValidateWebBinding(ip, tlsCert, tlsKey string) error {
+	if (tlsCert == "") != (tlsKey == "") {
+		return fmt.Errorf("TLS certificate and key must be provided together")
+	}
+	useTLS := tlsCert != "" && tlsKey != ""
+	if !useTLS && !isLoopback(ip) {
+		return fmt.Errorf("binding web server to non-loopback address %s requires TLS (--tls-cert and --tls-key)", ip)
+	}
+	if useTLS {
+		if _, err := os.Stat(tlsCert); err != nil {
+			return fmt.Errorf("TLS certificate file: %w", err)
+		}
+		if _, err := os.Stat(tlsKey); err != nil {
+			return fmt.Errorf("TLS key file: %w", err)
+		}
+	}
+	return nil
+}
+
 // RunWebServer is used to start the web server goroutine.
-func RunWebServer(ip string, port int, wg *sync.WaitGroup, ctx context.Context, sc *stats.Collector, username, hashedPassword string) {
+// If tlsCert and tlsKey are empty, the server uses plain HTTP and requires
+// a loopback bind address. Non-loopback addresses require TLS to protect
+// credentials in transit.
+func RunWebServer(ip string, port int, wg *sync.WaitGroup, ctx context.Context, sc *stats.Collector, username, hashedPassword, tlsCert, tlsKey string) {
 	defer wg.Done()
+
+	// Enforce loopback-only for non-TLS to protect credentials
+	useTLS := tlsCert != "" && tlsKey != ""
+	if !useTLS && !isLoopback(ip) {
+		log.Printf("Refusing to start web server on non-loopback address %s without TLS. "+
+			"Provide --tls-cert and --tls-key, or bind to 127.0.0.1.\n", ip)
+		return
+	}
+
 	listenAddr := ip + ":" + strconv.Itoa(port)
-	log.Printf("Starting Web server %s\n", listenAddr)
+	if useTLS {
+		log.Printf("Starting Web server with TLS on %s\n", listenAddr)
+	} else {
+		log.Printf("Starting Web server on %s\n", listenAddr)
+	}
 
 	router := http.NewServeMux()
 
@@ -116,15 +166,29 @@ func RunWebServer(ip string, port int, wg *sync.WaitGroup, ctx context.Context, 
 		WriteTimeout:      time.Second * 5,
 		IdleTimeout:       time.Second * 5,
 	}
+
+	serverErr := make(chan error, 1)
 	go func() {
-		err := srv.ListenAndServe()
-		if err != nil && err != http.ErrServerClosed {
-			log.Printf("Issue starting web server! %v\n", err)
-			return
+		if useTLS {
+			srv.TLSConfig = &tls.Config{
+				MinVersion: tls.VersionTLS12,
+			}
+			serverErr <- srv.ListenAndServeTLS(tlsCert, tlsKey)
+		} else {
+			serverErr <- srv.ListenAndServe()
 		}
 	}()
-	<-ctx.Done() // Block until context is cancelled
-	log.Printf("Web server Exiting due to signal\n")
+
+	// Wait for context cancellation or server error
+	select {
+	case <-ctx.Done():
+		log.Printf("Web server Exiting due to signal\n")
+	case err := <-serverErr:
+		if err != nil && err != http.ErrServerClosed {
+			log.Printf("Web server error: %v\n", err)
+		}
+	}
+
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer shutdownCancel()
 	_ = srv.Shutdown(shutdownCtx)

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -66,7 +66,7 @@ func TestRun(t *testing.T) {
 	// run web server
 	wg.Add(1)
 	hashedPassword, _ := bcrypt.GenerateFromPassword([]byte("testpass"), bcrypt.DefaultCost)
-	go RunWebServer(webIP, webPort, wg, ctx, sc, "admin", string(hashedPassword))
+	go RunWebServer(webIP, webPort, wg, ctx, sc, "admin", string(hashedPassword), "", "")
 	// check that it is serving up status page
 	time.Sleep(time.Second * 2)
 	// do check with auth
@@ -322,7 +322,7 @@ func TestRunWithMockedCollector(t *testing.T) {
 	wg.Add(2)
 	go sc.Run(&wg, ctx)
 	hashedPassword, _ := bcrypt.GenerateFromPassword([]byte("testpass"), bcrypt.DefaultCost)
-	go RunWebServer(webIP, webPort, &wg, ctx, sc, "admin", string(hashedPassword))
+	go RunWebServer(webIP, webPort, &wg, ctx, sc, "admin", string(hashedPassword), "", "")
 
 	// Allow server to start
 	time.Sleep(2 * time.Second)
@@ -413,5 +413,14 @@ func TestBasicAuthMiddleware(t *testing.T) {
 				t.Errorf("wanted %d, got %d", tt.wantStatus, rec.Code)
 			}
 		})
+	}
+}
+
+func TestValidateWebBindingRejectsPartialTLSConfig(t *testing.T) {
+	if err := ValidateWebBinding("127.0.0.1", "cert.pem", ""); err == nil {
+		t.Fatal("expected error when TLS key is missing")
+	}
+	if err := ValidateWebBinding("127.0.0.1", "", "key.pem"); err == nil {
+		t.Fatal("expected error when TLS certificate is missing")
 	}
 }


### PR DESCRIPTION
## Summary

- restore a compiling command/runtime API by completing error-returning `RunCtx` implementations for record, replay, and proxy modes
- validate CLI and YAML configuration before opening sockets, databases, or goroutines
- coordinate component failures with context cancellation and propagate errors to the CLI
- append recording keys safely, prevent empty replay loops from busy-spinning, and make replay throttling cancellation-aware
- clean up UDP connections and OS signal registrations without goroutine leaks
- require TLS for non-loopback web bindings and verify complete certificate/key pairs
- harden CI action pinning, release download checksums, vet/race coverage, and security scanning

## Verification

- `gofmt -l .`
- `go build ./...`
- `go vet ./...`
- `go test -v ./... -count 1`
- `go test -race ./... -count 1`
- `GOEXPERIMENT=goroutineleakprofile go test ./... -count 1`
- `gosec -exclude=G115 ./...` — 0 issues
- Trivy filesystem scan — 0 high/critical vulnerabilities, secrets, or Dockerfile misconfigurations
- `git diff --check`

## Notes

No outstanding branch contained the missing runtime implementation. This PR completes the partial refactor already present in the worktree and adds regression coverage for listener failures, persistence key continuation, replay cancellation, signal cleanup, and TLS validation.