### PR TITLE
Refactor: convert random number functions from panic to error returns

### DIFF
--- a/barrage/barrage.go
+++ b/barrage/barrage.go
@@ -56,7 +56,11 @@ func worker(cfg *workerConfig) {
 	}
 
 	// Configure connection to use. It looks like a listener, but it will be used to send packet. Allows setting the source port.
-	srcPort := utils.RandomNum(sourcePortMin, sourcePortMax)
+	srcPort, err := utils.RandomNum(sourcePortMin, sourcePortMax)
+	if err != nil {
+		log.Printf("%s [%2d] RandomNum failed: %v", label, cfg.id, err)
+		return
+	}
 
 	conn, err := net.ListenUDP("udp", &net.UDPAddr{Port: srcPort})
 	if err != nil {
@@ -122,7 +126,11 @@ func worker(cfg *workerConfig) {
 			wStats.BytesSent += uint64(bytes)
 			cfg.statsChan <- wStats
 		case <-dataLimiter.C:
-			flowCount := utils.RandomNum(5, 25)
+			flowCount, err := utils.RandomNum(5, 25)
+				if err != nil {
+					log.Printf("%s [%2d] RandomNum failed: %v", label, cfg.id, err)
+					return
+				}
 			buf, err := cfg.gen.GenerateData(flowCount, cfg.sourceID, cfg.srcRange, cfg.dstRange, session)
 			if err != nil {
 				log.Printf("%s [%2d] GenerateData failed: %v", label, cfg.id, err)
@@ -175,7 +183,11 @@ func StartCtx(ctx context.Context, config *models.Config, gen FlowGenerator) *Ru
 	// Start up the workers
 	wg.Add(config.Workers)
 	for w := 1; w <= config.Workers; w++ {
-		sourceID := utils.RandomNum(sourceIDMin, sourceIDMax)
+		sourceID, err := utils.RandomNum(sourceIDMin, sourceIDMax)
+			if err != nil {
+				log.Printf("Failed to generate source ID for worker %d: %v", w, err)
+				continue
+			}
 		// Each worker gets its own generator with independent sequence counter
 		workerGen := gen.ForWorker()
 		go worker(&workerConfig{

--- a/cmd/ipfix_single.go
+++ b/cmd/ipfix_single.go
@@ -48,9 +48,16 @@ func (c *IPFIXCommand) ParseFlags(args []string) error {
 // Execute runs the ipfix mode with parsed flags.
 func (c *IPFIXCommand) Execute() error {
 	if *c.srcPort == 0 {
-		*c.srcPort = utils.RandomNum(ipfixSourcePortMin, ipfixSourcePortMax)
+		var err error
+		*c.srcPort, err = utils.RandomNum(ipfixSourcePortMin, ipfixSourcePortMax)
+		if err != nil {
+			return fmt.Errorf("generate source port: %w", err)
+		}
 	}
-	sourceID := utils.RandomNum(ipfixSourceIDMin, ipfixSourceIDMax)
+	sourceID, err := utils.RandomNum(ipfixSourceIDMin, ipfixSourceIDMax)
+	if err != nil {
+		return fmt.Errorf("generate source ID: %w", err)
+	}
 
 	conn, err := net.ListenUDP("udp", &net.UDPAddr{Port: *c.srcPort})
 	if err != nil {

--- a/ipfix/ipfix.go
+++ b/ipfix/ipfix.go
@@ -264,14 +264,27 @@ func (gf *GenericFlow) GetTemplateFields() []Field {
 }
 
 // Generate creates a GenericFlow with randomly generated data.
-func (gf *GenericFlow) Generate(srcIP net.IP, dstIP net.IP, flowSrcPort int, session *netflow.Session) GenericFlow {
+func (gf *GenericFlow) Generate(srcIP net.IP, dstIP net.IP, flowSrcPort int, session *netflow.Session) (GenericFlow, error) {
 	now := time.Now()
 	epochMillis := uint64(now.UnixMilli())
 
-	gf.OctetDeltaCount = utils.GenerateRand32(10000)
-	gf.PostOctetDeltaCount = utils.GenerateRand32(10000)
-	gf.PacketDeltaCount = utils.GenerateRand32(10000)
-	gf.PostPacketDeltaCount = utils.GenerateRand32(10000)
+	var err error
+	gf.OctetDeltaCount, err = utils.GenerateRand32(10000)
+	if err != nil {
+		return GenericFlow{}, fmt.Errorf("generate OctetDeltaCount: %w", err)
+	}
+	gf.PostOctetDeltaCount, err = utils.GenerateRand32(10000)
+	if err != nil {
+		return GenericFlow{}, fmt.Errorf("generate PostOctetDeltaCount: %w", err)
+	}
+	gf.PacketDeltaCount, err = utils.GenerateRand32(10000)
+	if err != nil {
+		return GenericFlow{}, fmt.Errorf("generate PacketDeltaCount: %w", err)
+	}
+	gf.PostPacketDeltaCount, err = utils.GenerateRand32(10000)
+	if err != nil {
+		return GenericFlow{}, fmt.Errorf("generate PostPacketDeltaCount: %w", err)
+	}
 
 	if srcIP.To4() != nil {
 		gf.SourceIPv4Addr = utils.IPToNum(srcIP)
@@ -289,17 +302,28 @@ func (gf *GenericFlow) Generate(srcIP net.IP, dstIP net.IP, flowSrcPort int, ses
 		gf.DestIPv6Prefix = 64
 	}
 
-	gf.SourcePort = utils.GenerateRand16(10000)
-	gf.TCPFlags = uint8(utils.RandomNum(0, 32))
+	gf.SourcePort, err = utils.GenerateRand16(10000)
+	if err != nil {
+		return GenericFlow{}, fmt.Errorf("generate SourcePort: %w", err)
+	}
+	tcpFlags, err := utils.RandomNum(0, 32)
+	if err != nil {
+		return GenericFlow{}, fmt.Errorf("generate TCPFlags: %w", err)
+	}
+	gf.TCPFlags = uint8(tcpFlags)
 	gf.FlowStartMillis = epochMillis - 100
 	gf.FlowEndMillis = epochMillis - 10
 	gf.FlowDirection = 0
 	gf.IPClassOfService = 0
-	gf.FlowEndReason = uint8(utils.RandomNum(0, 4))
+	flowEndReason, err := utils.RandomNum(0, 4)
+	if err != nil {
+		return GenericFlow{}, fmt.Errorf("generate FlowEndReason: %w", err)
+	}
+	gf.FlowEndReason = uint8(flowEndReason)
 
 	gf.DestPort, gf.ProtocolIdentifier = utils.ResolvePortProtocol(flowSrcPort)
 
-	return *gf
+	return *gf, nil
 }
 
 // DataAny holds a data record of any type.
@@ -331,9 +355,17 @@ func (d *DataFlowSet) Generate(flowCount int, srcRange string, dstRange string, 
 		}
 		port := flowSrcPort
 		if port == 0 {
-			port = protoPorts[utils.RandomNum(0, len(protoPorts))]
+			idx, err := utils.RandomNum(0, len(protoPorts))
+			if err != nil {
+				return DataFlowSet{}, fmt.Errorf("select random port for flow %d: %w", i, err)
+			}
+			port = protoPorts[idx]
 		}
-		items[i] = new(GenericFlow).Generate(srcIP, dstIP, port, session)
+		flow, err := new(GenericFlow).Generate(srcIP, dstIP, port, session)
+		if err != nil {
+			return DataFlowSet{}, fmt.Errorf("generate flow %d: %w", i, err)
+		}
+		items[i] = flow
 	}
 
 	// Calculate length: FlowSetID(2) + Length(2) + records + padding

--- a/ipfix/ipfix_coverage_test.go
+++ b/ipfix/ipfix_coverage_test.go
@@ -153,7 +153,10 @@ func TestMinimalIPFIXFlow_Generate(t *testing.T) {
 	srcIP := net.ParseIP("10.0.0.1")
 	dstIP := net.ParseIP("10.0.0.2")
 
-	mf := new(MinimalIPFIXFlow).Generate(srcIP, dstIP, utils.HTTPSPort, nil)
+	mf, err := new(MinimalIPFIXFlow).Generate(srcIP, dstIP, utils.HTTPSPort, nil)
+	if err != nil {
+		t.Fatalf("MinimalIPFIXFlow.Generate error: %v", err)
+	}
 
 	if mf.SourceIPv4Addr == 0 {
 		t.Error("SourceIPv4Addr should not be zero")
@@ -180,7 +183,10 @@ func TestMinimalIPFIXFlow_Generate_IPv6(t *testing.T) {
 	srcIP := net.ParseIP("2001:db8::1")
 	dstIP := net.ParseIP("2001:db8::2")
 
-	mf := new(MinimalIPFIXFlow).Generate(srcIP, dstIP, utils.HTTPSPort, nil)
+	mf, err := new(MinimalIPFIXFlow).Generate(srcIP, dstIP, utils.HTTPSPort, nil)
+	if err != nil {
+		t.Fatalf("MinimalIPFIXFlow.Generate error: %v", err)
+	}
 
 	if mf.SourceIPv4Addr != 0 {
 		t.Errorf("IPv4 src should be zeroed for IPv6 input, got %d", mf.SourceIPv4Addr)
@@ -210,7 +216,10 @@ func TestMinimalIPFIXFlow_Generate_AllProtocols(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("port_%d", tc.port), func(t *testing.T) {
-			mf := new(MinimalIPFIXFlow).Generate(srcIP, dstIP, tc.port, nil)
+			mf, err := new(MinimalIPFIXFlow).Generate(srcIP, dstIP, tc.port, nil)
+				if err != nil {
+					t.Fatalf("MinimalIPFIXFlow.Generate error: %v", err)
+				}
 			if mf.DestPort != tc.wantPort {
 				t.Errorf("DestPort: got %d, want %d", mf.DestPort, tc.wantPort)
 			}
@@ -640,7 +649,10 @@ func TestGenericFlow_Generate_AllProtocols(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("port_%d", tc.port), func(t *testing.T) {
-			gf := new(GenericFlow).Generate(srcIP, dstIP, tc.port, nil)
+			gf, err := new(GenericFlow).Generate(srcIP, dstIP, tc.port, nil)
+				if err != nil {
+					t.Fatalf("GenericFlow.Generate error: %v", err)
+				}
 			if gf.DestPort != tc.wantPort {
 				t.Errorf("DestPort: got %d, want %d", gf.DestPort, tc.wantPort)
 			}
@@ -671,7 +683,10 @@ func TestGenericFlow_EpochMilliseconds(t *testing.T) {
 	srcIP := net.ParseIP("10.0.0.1")
 	dstIP := net.ParseIP("10.0.0.2")
 
-	gf := new(GenericFlow).Generate(srcIP, dstIP, utils.HTTPSPort, nil)
+	gf, err := new(GenericFlow).Generate(srcIP, dstIP, utils.HTTPSPort, nil)
+	if err != nil {
+		t.Fatalf("GenericFlow.Generate error: %v", err)
+	}
 
 	nowMillis := uint64(time.Now().UnixMilli())
 	if gf.FlowStartMillis == 0 {

--- a/ipfix/ipfix_test.go
+++ b/ipfix/ipfix_test.go
@@ -529,7 +529,10 @@ func TestGenericFlowIPv6(t *testing.T) {
 	srcIP := net.ParseIP("2001:db8::1")
 	dstIP := net.ParseIP("2001:db8::2")
 
-	result := new(GenericFlow).Generate(srcIP, dstIP, utils.HTTPSPort, nil)
+	result, err := new(GenericFlow).Generate(srcIP, dstIP, utils.HTTPSPort, nil)
+	if err != nil {
+		t.Fatalf("GenericFlow.Generate error: %v", err)
+	}
 
 	if result.SourceIPv4Addr != 0 {
 		t.Errorf("expected zeroed IPv4 src, got %d", result.SourceIPv4Addr)
@@ -563,7 +566,10 @@ func TestGenericFlowIPv4_ZerosIPv6(t *testing.T) {
 	srcIP := net.ParseIP("10.0.0.1")
 	dstIP := net.ParseIP("10.0.0.2")
 
-	result := new(GenericFlow).Generate(srcIP, dstIP, utils.HTTPSPort, nil)
+	result, err := new(GenericFlow).Generate(srcIP, dstIP, utils.HTTPSPort, nil)
+	if err != nil {
+		t.Fatalf("GenericFlow.Generate error: %v", err)
+	}
 
 	if result.SourceIPv4Addr == 0 {
 		t.Error("expected non-zero IPv4 src")

--- a/ipfix/profile_generic.go
+++ b/ipfix/profile_generic.go
@@ -4,6 +4,7 @@
 package ipfix
 
 import (
+	"fmt"
 	"net"
 
 	"github.com/dmabry/flowgre/netflow"
@@ -83,9 +84,16 @@ type MinimalIPFIXFlow struct {
 }
 
 // Generate creates a MinimalIPFIXFlow with randomly generated data.
-func (mf *MinimalIPFIXFlow) Generate(srcIP net.IP, dstIP net.IP, flowSrcPort int, session *netflow.Session) MinimalIPFIXFlow {
-	mf.OctetDeltaCount = utils.GenerateRand32(10000)
-	mf.PacketDeltaCount = utils.GenerateRand32(10000)
+func (mf *MinimalIPFIXFlow) Generate(srcIP net.IP, dstIP net.IP, flowSrcPort int, session *netflow.Session) (MinimalIPFIXFlow, error) {
+	var err error
+	mf.OctetDeltaCount, err = utils.GenerateRand32(10000)
+	if err != nil {
+		return MinimalIPFIXFlow{}, fmt.Errorf("generate OctetDeltaCount: %w", err)
+	}
+	mf.PacketDeltaCount, err = utils.GenerateRand32(10000)
+	if err != nil {
+		return MinimalIPFIXFlow{}, fmt.Errorf("generate PacketDeltaCount: %w", err)
+	}
 
 	if srcIP.To4() != nil {
 		mf.SourceIPv4Addr = utils.IPToNum(srcIP)
@@ -95,7 +103,10 @@ func (mf *MinimalIPFIXFlow) Generate(srcIP net.IP, dstIP net.IP, flowSrcPort int
 		mf.DestIPv4Addr = 0
 	}
 
-	mf.SourcePort = utils.GenerateRand16(10000)
+	mf.SourcePort, err = utils.GenerateRand16(10000)
+	if err != nil {
+		return MinimalIPFIXFlow{}, fmt.Errorf("generate SourcePort: %w", err)
+	}
 	mf.ProtocolIdentifier = utils.TCPProto
 
 	switch flowSrcPort {
@@ -119,7 +130,7 @@ func (mf *MinimalIPFIXFlow) Generate(srcIP net.IP, dstIP net.IP, flowSrcPort int
 		mf.ProtocolIdentifier = utils.TCPProto
 	}
 
-	return *mf
+	return *mf, nil
 }
 
 // ExtendedIPFIXProfile generates an extended IPFIX flow with additional fields.

--- a/netflow/coverage_test.go
+++ b/netflow/coverage_test.go
@@ -429,7 +429,10 @@ func TestGenericFlow_Generate_AllProtocols(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("port_%d", tc.port), func(t *testing.T) {
 			session := NewSession()
-			gf := new(GenericFlow).Generate(srcIP, dstIP, tc.port, session)
+			gf, err := new(GenericFlow).Generate(srcIP, dstIP, tc.port, session)
+				if err != nil {
+					t.Fatalf("GenericFlow.Generate error: %v", err)
+				}
 			if gf.L4DstPort != tc.wantPort {
 				t.Errorf("L4DstPort: got %d, want %d", gf.L4DstPort, tc.wantPort)
 			}

--- a/netflow/dataflowset.go
+++ b/netflow/dataflowset.go
@@ -45,11 +45,19 @@ func (d *DataFlowSet) Generate(flowCount int, srcRange string, dstRange string, 
 		}
 		var flowPort int
 		if flowSrcPort == 0 {
-			flowPort = protoPorts[utils.RandomNum(0, len(protoPorts))]
+			idx, err := utils.RandomNum(0, len(protoPorts))
+			if err != nil {
+				return DataFlowSet{}, fmt.Errorf("select random port for flow %d: %w", i, err)
+			}
+			flowPort = protoPorts[idx]
 		} else {
 			flowPort = flowSrcPort
 		}
-		items[i] = generateFlow(p, srcIP, dstIP, flowPort, session)
+		flow, err := generateFlow(p, srcIP, dstIP, flowPort, session)
+		if err != nil {
+			return DataFlowSet{}, fmt.Errorf("generate flow %d: %w", i, err)
+		}
+		items[i] = flow
 	}
 	dataFlowSet.Items = items
 	size := dataFlowSet.size()
@@ -61,7 +69,7 @@ func (d *DataFlowSet) Generate(flowCount int, srcRange string, dstRange string, 
 }
 
 // generateFlow creates a flow record appropriate for the given profile.
-func generateFlow(p FlowProfile, srcIP, dstIP net.IP, flowPort int, session *Session) any {
+func generateFlow(p FlowProfile, srcIP, dstIP net.IP, flowPort int, session *Session) (any, error) {
 	switch prof := p.(type) {
 	case *MinimalProfile:
 		_ = prof

--- a/netflow/flow.go
+++ b/netflow/flow.go
@@ -4,6 +4,7 @@
 package netflow
 
 import (
+	"fmt"
 	"net"
 	"time"
 
@@ -158,14 +159,27 @@ func (gf *GenericFlow) GetTemplateFields() []Field {
 
 // Generate returns a NetFlow v9 Flow with randomly generated payload.
 // Populates both IPv4 and IPv6 fields based on the input IP version.
-func (gf *GenericFlow) Generate(srcIP net.IP, dstIP net.IP, flowSrcPort int, session *Session) GenericFlow {
+func (gf *GenericFlow) Generate(srcIP net.IP, dstIP net.IP, flowSrcPort int, session *Session) (GenericFlow, error) {
 	now := time.Now().UnixNano()
 	startTime := session.StartTime()
 	uptime := uint32((now-startTime)/int64(time.Millisecond)) + 1000
-	gf.InBytes = utils.GenerateRand32(10000)
-	gf.OutBytes = utils.GenerateRand32(10000)
-	gf.InPkts = utils.GenerateRand32(10000)
-	gf.OutPkts = utils.GenerateRand32(10000)
+	var err error
+	gf.InBytes, err = utils.GenerateRand32(10000)
+	if err != nil {
+		return GenericFlow{}, fmt.Errorf("generate InBytes: %w", err)
+	}
+	gf.OutBytes, err = utils.GenerateRand32(10000)
+	if err != nil {
+		return GenericFlow{}, fmt.Errorf("generate OutBytes: %w", err)
+	}
+	gf.InPkts, err = utils.GenerateRand32(10000)
+	if err != nil {
+		return GenericFlow{}, fmt.Errorf("generate InPkts: %w", err)
+	}
+	gf.OutPkts, err = utils.GenerateRand32(10000)
+	if err != nil {
+		return GenericFlow{}, fmt.Errorf("generate OutPkts: %w", err)
+	}
 
 	// Populate IP addresses based on version
 	if srcIP.To4() != nil {
@@ -184,8 +198,15 @@ func (gf *GenericFlow) Generate(srcIP net.IP, dstIP net.IP, flowSrcPort int, ses
 		gf.Ipv6DstMask = 64 // Default /64 mask
 	}
 
-	gf.L4SrcPort = utils.GenerateRand16(10000)
-	gf.TcpFlags = uint8(utils.RandomNum(0, 32))
+	gf.L4SrcPort, err = utils.GenerateRand16(10000)
+	if err != nil {
+		return GenericFlow{}, fmt.Errorf("generate L4SrcPort: %w", err)
+	}
+	tcpFlags, err := utils.RandomNum(0, 32)
+	if err != nil {
+		return GenericFlow{}, fmt.Errorf("generate TcpFlags: %w", err)
+	}
+	gf.TcpFlags = uint8(tcpFlags)
 	gf.FirstSwitched = uptime - 100
 	gf.LastSwitched = uptime - 10
 	gf.EngineType = 0
@@ -193,5 +214,5 @@ func (gf *GenericFlow) Generate(srcIP net.IP, dstIP net.IP, flowSrcPort int, ses
 
 	gf.L4DstPort, gf.Protocol = utils.ResolvePortProtocol(flowSrcPort)
 
-	return *gf
+	return *gf, nil
 }

--- a/netflow/netflow_test.go
+++ b/netflow/netflow_test.go
@@ -236,7 +236,10 @@ func TestGenericFlowIPv6(t *testing.T) {
 	session := NewSession()
 
 	gf := new(GenericFlow)
-	result := gf.Generate(srcIP, dstIP, utils.HTTPSPort, session)
+	result, err := gf.Generate(srcIP, dstIP, utils.HTTPSPort, session)
+	if err != nil {
+		t.Fatalf("GenericFlow.Generate error: %v", err)
+	}
 
 	// IPv4 fields should be zeroed
 	if result.Ipv4SrcAddr != 0 {
@@ -275,7 +278,10 @@ func TestGenericFlowIPv4BackwardCompat(t *testing.T) {
 	session := NewSession()
 
 	gf := new(GenericFlow)
-	result := gf.Generate(srcIP, dstIP, utils.HTTPSPort, session)
+	result, err := gf.Generate(srcIP, dstIP, utils.HTTPSPort, session)
+	if err != nil {
+		t.Fatalf("GenericFlow.Generate error: %v", err)
+	}
 
 	// IPv4 fields should be populated
 	if result.Ipv4SrcAddr != utils.IPToNum(srcIP) {

--- a/netflow/profile_coverage_test.go
+++ b/netflow/profile_coverage_test.go
@@ -38,7 +38,10 @@ func TestMinimalFlow_Generate_AllProtocols(t *testing.T) {
 	for _, tc := range cases {
 		t.Run("", func(t *testing.T) {
 			session := NewSession()
-			mf := new(MinimalFlow).Generate(srcIP, dstIP, tc.port, session)
+			mf, err := new(MinimalFlow).Generate(srcIP, dstIP, tc.port, session)
+				if err != nil {
+					t.Fatalf("MinimalFlow.Generate error: %v", err)
+				}
 			if mf.DstPort != tc.wantPort {
 				t.Errorf("DstPort: got %d, want %d", mf.DstPort, tc.wantPort)
 			}
@@ -77,7 +80,10 @@ func TestExtendedFlow_Generate_AllProtocols(t *testing.T) {
 	for _, tc := range cases {
 		t.Run("", func(t *testing.T) {
 			session := NewSession()
-			ef := new(ExtendedFlow).Generate(srcIP, dstIP, tc.port, session)
+			ef, err := new(ExtendedFlow).Generate(srcIP, dstIP, tc.port, session)
+				if err != nil {
+					t.Fatalf("ExtendedFlow.Generate error: %v", err)
+				}
 			if ef.DstPort != tc.wantPort {
 				t.Errorf("DstPort: got %d, want %d", ef.DstPort, tc.wantPort)
 			}
@@ -95,7 +101,10 @@ func TestMinimalFlow_Generate_IPv6(t *testing.T) {
 	srcIP := net.ParseIP("2001:db8::1")
 	dstIP := net.ParseIP("2001:db8::2")
 
-	mf := new(MinimalFlow).Generate(srcIP, dstIP, utils.HTTPSPort, session)
+	mf, err := new(MinimalFlow).Generate(srcIP, dstIP, utils.HTTPSPort, session)
+	if err != nil {
+		t.Fatalf("MinimalFlow.Generate error: %v", err)
+	}
 
 	// IPv4 fields should be zeroed for IPv6
 	if mf.SrcAddr != 0 {
@@ -113,7 +122,10 @@ func TestExtendedFlow_Generate_IPv6(t *testing.T) {
 	srcIP := net.ParseIP("2001:db8::1")
 	dstIP := net.ParseIP("2001:db8::2")
 
-	ef := new(ExtendedFlow).Generate(srcIP, dstIP, utils.HTTPSPort, session)
+	ef, err := new(ExtendedFlow).Generate(srcIP, dstIP, utils.HTTPSPort, session)
+	if err != nil {
+		t.Fatalf("ExtendedFlow.Generate error: %v", err)
+	}
 
 	// IPv4 fields should be zeroed for IPv6
 	if ef.SrcAddr != 0 {

--- a/netflow/profile_extended.go
+++ b/netflow/profile_extended.go
@@ -4,6 +4,7 @@
 package netflow
 
 import (
+	"fmt"
 	"net"
 	"time"
 
@@ -58,13 +59,20 @@ type ExtendedFlow struct {
 }
 
 // Generate creates an ExtendedFlow with randomly generated data.
-func (ef *ExtendedFlow) Generate(srcIP net.IP, dstIP net.IP, flowSrcPort int, session *Session) ExtendedFlow {
+func (ef *ExtendedFlow) Generate(srcIP net.IP, dstIP net.IP, flowSrcPort int, session *Session) (ExtendedFlow, error) {
 	now := time.Now().UnixNano()
 	startTime := session.StartTime()
 	uptime := uint32((now-startTime)/int64(time.Millisecond)) + 1000
 
-	ef.InBytes = utils.GenerateRand32(10000)
-	ef.InPkts = utils.GenerateRand32(10000)
+	var err error
+	ef.InBytes, err = utils.GenerateRand32(10000)
+	if err != nil {
+		return ExtendedFlow{}, fmt.Errorf("generate InBytes: %w", err)
+	}
+	ef.InPkts, err = utils.GenerateRand32(10000)
+	if err != nil {
+		return ExtendedFlow{}, fmt.Errorf("generate InPkts: %w", err)
+	}
 
 	if srcIP.To4() != nil {
 		ef.SrcAddr = utils.IPToNum(srcIP)
@@ -74,31 +82,50 @@ func (ef *ExtendedFlow) Generate(srcIP net.IP, dstIP net.IP, flowSrcPort int, se
 		ef.DstAddr = 0
 	}
 
-	ef.SrcPort = utils.GenerateRand16(10000)
-	ef.SrcMac = [6]byte{
-		uint8(utils.RandomNum(0, 256)),
-		uint8(utils.RandomNum(0, 256)),
-		uint8(utils.RandomNum(0, 256)),
-		uint8(utils.RandomNum(0, 256)),
-		uint8(utils.RandomNum(0, 256)),
-		uint8(utils.RandomNum(0, 256)),
+	ef.SrcPort, err = utils.GenerateRand16(10000)
+	if err != nil {
+		return ExtendedFlow{}, fmt.Errorf("generate SrcPort: %w", err)
 	}
-	ef.DstMac = [6]byte{
-		uint8(utils.RandomNum(0, 256)),
-		uint8(utils.RandomNum(0, 256)),
-		uint8(utils.RandomNum(0, 256)),
-		uint8(utils.RandomNum(0, 256)),
-		uint8(utils.RandomNum(0, 256)),
-		uint8(utils.RandomNum(0, 256)),
+	ef.SrcMac = [6]byte{}
+	for i := range ef.SrcMac {
+		val, err := utils.RandomNum(0, 256)
+		if err != nil {
+			return ExtendedFlow{}, fmt.Errorf("generate SrcMac byte %d: %w", i, err)
+		}
+		ef.SrcMac[i] = uint8(val)
 	}
-	ef.SrcVlan = uint16(utils.RandomNum(1, 4094))
-	ef.DstVlan = uint16(utils.RandomNum(1, 4094))
-	ef.MinTtl = uint8(utils.RandomNum(1, 128))
-	ef.MaxTtl = uint8(utils.RandomNum(1, 128))
+	ef.DstMac = [6]byte{}
+	for i := range ef.DstMac {
+		val, err := utils.RandomNum(0, 256)
+		if err != nil {
+			return ExtendedFlow{}, fmt.Errorf("generate DstMac byte %d: %w", i, err)
+		}
+		ef.DstMac[i] = uint8(val)
+	}
+	srcVlan, err := utils.RandomNum(1, 4094)
+	if err != nil {
+		return ExtendedFlow{}, fmt.Errorf("generate SrcVlan: %w", err)
+	}
+	ef.SrcVlan = uint16(srcVlan)
+	dstVlan, err := utils.RandomNum(1, 4094)
+	if err != nil {
+		return ExtendedFlow{}, fmt.Errorf("generate DstVlan: %w", err)
+	}
+	ef.DstVlan = uint16(dstVlan)
+	minTtl, err := utils.RandomNum(1, 128)
+	if err != nil {
+		return ExtendedFlow{}, fmt.Errorf("generate MinTtl: %w", err)
+	}
+	ef.MinTtl = uint8(minTtl)
+	maxTtl, err := utils.RandomNum(1, 128)
+	if err != nil {
+		return ExtendedFlow{}, fmt.Errorf("generate MaxTtl: %w", err)
+	}
+	ef.MaxTtl = uint8(maxTtl)
 	ef.FirstSwitched = uptime - 100
 	ef.LastSwitched = uptime - 10
 
 	ef.DstPort, ef.Protocol = utils.ResolvePortProtocol(flowSrcPort)
 
-	return *ef
+	return *ef, nil
 }

--- a/netflow/profile_minimal.go
+++ b/netflow/profile_minimal.go
@@ -4,6 +4,7 @@
 package netflow
 
 import (
+	"fmt"
 	"net"
 
 	"github.com/dmabry/flowgre/utils"
@@ -42,9 +43,16 @@ type MinimalFlow struct {
 }
 
 // Generate creates a MinimalFlow with randomly generated data.
-func (mf *MinimalFlow) Generate(srcIP net.IP, dstIP net.IP, flowSrcPort int, session *Session) MinimalFlow {
-	mf.InBytes = utils.GenerateRand32(10000)
-	mf.InPkts = utils.GenerateRand32(10000)
+func (mf *MinimalFlow) Generate(srcIP net.IP, dstIP net.IP, flowSrcPort int, session *Session) (MinimalFlow, error) {
+	var err error
+	mf.InBytes, err = utils.GenerateRand32(10000)
+	if err != nil {
+		return MinimalFlow{}, fmt.Errorf("generate InBytes: %w", err)
+	}
+	mf.InPkts, err = utils.GenerateRand32(10000)
+	if err != nil {
+		return MinimalFlow{}, fmt.Errorf("generate InPkts: %w", err)
+	}
 
 	if srcIP.To4() != nil {
 		mf.SrcAddr = utils.IPToNum(srcIP)
@@ -54,9 +62,12 @@ func (mf *MinimalFlow) Generate(srcIP net.IP, dstIP net.IP, flowSrcPort int, ses
 		mf.DstAddr = 0
 	}
 
-	mf.SrcPort = utils.GenerateRand16(10000)
+	mf.SrcPort, err = utils.GenerateRand16(10000)
+	if err != nil {
+		return MinimalFlow{}, fmt.Errorf("generate SrcPort: %w", err)
+	}
 
 	mf.DstPort, mf.Protocol = utils.ResolvePortProtocol(flowSrcPort)
 
-	return *mf
+	return *mf, nil
 }

--- a/netflow/profile_minimal_test.go
+++ b/netflow/profile_minimal_test.go
@@ -167,7 +167,10 @@ func TestMinimalFlow_Generate(t *testing.T) {
 	srcIP := net.ParseIP("10.0.0.1")
 	dstIP := net.ParseIP("10.0.0.2")
 
-	mf := new(MinimalFlow).Generate(srcIP, dstIP, utils.HTTPSPort, session)
+	mf, err := new(MinimalFlow).Generate(srcIP, dstIP, utils.HTTPSPort, session)
+	if err != nil {
+		t.Fatalf("MinimalFlow.Generate error: %v", err)
+	}
 
 	if mf.SrcAddr == 0 {
 		t.Error("expected non-zero src addr")
@@ -190,7 +193,10 @@ func TestExtendedFlow_Generate(t *testing.T) {
 	srcIP := net.ParseIP("10.0.0.1")
 	dstIP := net.ParseIP("10.0.0.2")
 
-	ef := new(ExtendedFlow).Generate(srcIP, dstIP, utils.HTTPSPort, session)
+	ef, err := new(ExtendedFlow).Generate(srcIP, dstIP, utils.HTTPSPort, session)
+	if err != nil {
+		t.Fatalf("ExtendedFlow.Generate error: %v", err)
+	}
 
 	if ef.SrcAddr == 0 {
 		t.Error("expected non-zero src addr")

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -44,7 +44,10 @@ func worker(id int, ctx context.Context, server string, port int, wg *sync.WaitG
 func runWorker(id int, ctx context.Context, server string, port int, workerChan <-chan []byte) error {
 	// Sent limiter to given delay
 	// Configure connection to use.  It looks like a listener, but it will be used to send packet.  Allows me to set the source port
-	srcPort := utils.RandomNum(sourcePortMin, sourcePortMax)
+	srcPort, err := utils.RandomNum(sourcePortMin, sourcePortMax)
+	if err != nil {
+		return fmt.Errorf("generate source port: %w", err)
+	}
 	conn, err := net.ListenUDP("udp", &net.UDPAddr{Port: srcPort})
 	if err != nil {
 		return fmt.Errorf("listen on source port %d: %w", srcPort, err)

--- a/replay/replay.go
+++ b/replay/replay.go
@@ -50,7 +50,10 @@ func worker(id int, ctx context.Context, server string, port int, delay int, loo
 	limiter := time.NewTicker(time.Millisecond * time.Duration(delay))
 	defer limiter.Stop()
 
-	srcPort := utils.RandomNum(10000, 15000)
+	srcPort, err := utils.RandomNum(10000, 15000)
+	if err != nil {
+		return fmt.Errorf("replay worker %d generate source port: %w", id, err)
+	}
 	conn, err := net.ListenUDP("udp", &net.UDPAddr{Port: srcPort})
 	if err != nil {
 		return fmt.Errorf("replay worker %d listen: %w", id, err)

--- a/replay/replay_test.go
+++ b/replay/replay_test.go
@@ -344,7 +344,10 @@ func TestSendPacket(t *testing.T) {
 	<-receiverReady
 
 	// Send a packet
-	srcPort := utils.RandomNum(10000, 15000)
+	srcPort, err := utils.RandomNum(10000, 15000)
+	if err != nil {
+		t.Fatalf("RandomNum error: %v", err)
+	}
 	conn, err := net.ListenUDP("udp", &net.UDPAddr{Port: srcPort})
 	if err != nil {
 		t.Fatalf("Failed to listen: %v", err)

--- a/single/single.go
+++ b/single/single.go
@@ -35,10 +35,17 @@ func RunCtx(ctx context.Context, collectorIP string, destPort int, srcPort int, 
 	// Configure connection to use. It looks like a listener, but it will be used to send packet. Allows setting the source port.
 	if srcPort == 0 {
 		// Pick random source port between 10000 and 15000
-		srcPort = utils.RandomNum(sourcePortMin, sourcePortMax)
+		var err error
+		srcPort, err = utils.RandomNum(sourcePortMin, sourcePortMax)
+		if err != nil {
+			return fmt.Errorf("generate source port: %w", err)
+		}
 	} // else use the given srcPort number
 	// Generate random sourceID for all Netflow headers. This is essentially a virtual ID.
-	sourceID := utils.RandomNum(sourceIDMin, sourceIDMax)
+	sourceID, err := utils.RandomNum(sourceIDMin, sourceIDMax)
+	if err != nil {
+		return fmt.Errorf("generate source ID: %w", err)
+	}
 
 	conn, err := net.ListenUDP("udp", &net.UDPAddr{Port: srcPort})
 	if err != nil {

--- a/utils/ip.go
+++ b/utils/ip.go
@@ -67,7 +67,10 @@ func RandomIP(cidr string) (net.IP, error) {
 		randIP = NumToIP(ipMinNum)
 	} else {
 		rangeSize := int64(ipMaxNum - ipMinNum)
-		offset := CryptoRandomNumber(rangeSize)
+		offset, err := CryptoRandomNumber(rangeSize)
+		if err != nil {
+			return nil, fmt.Errorf("generate random IP offset: %w", err)
+		}
 		randIPNum := uint32(offset + int64(ipMinNum))
 		randIP = NumToIP(randIPNum)
 	}

--- a/utils/rand.go
+++ b/utils/rand.go
@@ -12,34 +12,50 @@ import (
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 // RandStringBytes generates a random string of given length using crypto/rand.
-func RandStringBytes(n int) string {
+func RandStringBytes(n int) (string, error) {
 	b := make([]byte, n)
 	for i := range b {
-		b[i] = letterBytes[CryptoRandomNumber(int64(len(letterBytes)))]
+		idx, err := CryptoRandomNumber(int64(len(letterBytes)))
+		if err != nil {
+			return "", fmt.Errorf("generate random char at index %d: %w", i, err)
+		}
+		b[i] = letterBytes[idx]
 	}
-	return string(b)
+	return string(b), nil
 }
 
 // CryptoRandomNumber generates a cryptographically secure random number in [0, max).
-func CryptoRandomNumber(max int64) int64 {
+func CryptoRandomNumber(max int64) (int64, error) {
 	n, err := rand.Int(rand.Reader, big.NewInt(max))
 	if err != nil {
-		panic(fmt.Errorf("crypto random failed: %w", err))
+		return 0, fmt.Errorf("crypto random failed: %w", err)
 	}
-	return n.Int64()
+	return n.Int64(), nil
 }
 
 // GenerateRand16 generates a random uint16 in [0, max).
-func GenerateRand16(max int) uint16 {
-	return uint16(CryptoRandomNumber(int64(max)))
+func GenerateRand16(max int) (uint16, error) {
+	n, err := CryptoRandomNumber(int64(max))
+	if err != nil {
+		return 0, fmt.Errorf("generate rand16: %w", err)
+	}
+	return uint16(n), nil
 }
 
 // GenerateRand32 generates a random uint32 in [0, max).
-func GenerateRand32(max int) uint32 {
-	return uint32(CryptoRandomNumber(int64(max)))
+func GenerateRand32(max int) (uint32, error) {
+	n, err := CryptoRandomNumber(int64(max))
+	if err != nil {
+		return 0, fmt.Errorf("generate rand32: %w", err)
+	}
+	return uint32(n), nil
 }
 
 // RandomNum generates a random integer in [min, max).
-func RandomNum(min, max int) int {
-	return int(CryptoRandomNumber(int64(max-min))) + min
+func RandomNum(min, max int) (int, error) {
+	n, err := CryptoRandomNumber(int64(max - min))
+	if err != nil {
+		return 0, fmt.Errorf("generate random num in [%d, %d): %w", min, max, err)
+	}
+	return int(n) + min, nil
 }

--- a/utils/utils_coverage_test.go
+++ b/utils/utils_coverage_test.go
@@ -361,7 +361,10 @@ func TestCryptoRandomNumber_EdgeCases(t *testing.T) {
 	t.Parallel()
 
 	// max=1 should always return 0
-	result := CryptoRandomNumber(1)
+	result, err := CryptoRandomNumber(1)
+	if err != nil {
+		t.Fatalf("CryptoRandomNumber(1) error: %v", err)
+	}
 	if result != 0 {
 		t.Errorf("CryptoRandomNumber(1) = %d, want 0", result)
 	}
@@ -369,7 +372,10 @@ func TestCryptoRandomNumber_EdgeCases(t *testing.T) {
 	// Verify distribution over a range
 	counts := make(map[int64]int)
 	for range 1000 {
-		n := CryptoRandomNumber(10)
+		n, err := CryptoRandomNumber(10)
+		if err != nil {
+			t.Fatalf("CryptoRandomNumber(10) error: %v", err)
+		}
 		counts[n]++
 	}
 	for k, c := range counts {
@@ -390,7 +396,10 @@ func TestRandStringBytes_Variants(t *testing.T) {
 
 	for _, n := range lengths {
 		t.Run(string(rune('0'+n)), func(t *testing.T) {
-			result := RandStringBytes(n)
+			result, err := RandStringBytes(n)
+			if err != nil {
+				t.Fatalf("RandStringBytes(%d) error: %v", n, err)
+			}
 			if len(result) != n {
 				t.Errorf("RandStringBytes(%d) length = %d, want %d", n, len(result), n)
 			}
@@ -415,12 +424,15 @@ func TestRandStringBytes_Variants(t *testing.T) {
 func TestRandomNum_BoundaryConditions(t *testing.T) {
 	t.Parallel()
 
-	// Note: RandomNum(min,min) panics because CryptoRandomNumber(0) panics.
-	// This is existing behavior — skipping that case.
+	// Note: RandomNum(min,min) returns an error because CryptoRandomNumber(0) errors.
+	// This is the updated behavior — skipping that case.
 
 	// Small positive range
 	for range 100 {
-		result := RandomNum(0, 1)
+		result, err := RandomNum(0, 1)
+		if err != nil {
+			t.Fatalf("RandomNum(0,1) error: %v", err)
+		}
 		if result != 0 {
 			t.Errorf("RandomNum(0,1) = %d, want 0", result)
 		}
@@ -428,7 +440,10 @@ func TestRandomNum_BoundaryConditions(t *testing.T) {
 
 	// Negative range
 	for range 100 {
-		result := RandomNum(-10, 0)
+		result, err := RandomNum(-10, 0)
+		if err != nil {
+			t.Fatalf("RandomNum(-10,0) error: %v", err)
+		}
 		if result < -10 || result >= 0 {
 			t.Errorf("RandomNum(-10,0) = %d, out of range [-10, 0)", result)
 		}
@@ -436,7 +451,10 @@ func TestRandomNum_BoundaryConditions(t *testing.T) {
 
 	// Medium range
 	for range 100 {
-		result := RandomNum(10, 100)
+		result, err := RandomNum(10, 100)
+		if err != nil {
+			t.Fatalf("RandomNum(10,100) error: %v", err)
+		}
 		if result < 10 || result >= 100 {
 			t.Errorf("RandomNum(10,100) = %d, out of range [10, 100)", result)
 		}
@@ -448,7 +466,10 @@ func TestGenerateRand16_LargeRange(t *testing.T) {
 	t.Parallel()
 	max := 65535
 	for range 100 {
-		result := GenerateRand16(max)
+		result, err := GenerateRand16(max)
+		if err != nil {
+			t.Fatalf("GenerateRand16(%d) error: %v", max, err)
+		}
 		if result >= uint16(max) {
 			t.Errorf("GenerateRand16(%d) = %d, want < %d", max, result, max)
 		}
@@ -460,7 +481,10 @@ func TestGenerateRand32_LargeRange(t *testing.T) {
 	t.Parallel()
 	max := 100000
 	for range 100 {
-		result := GenerateRand32(max)
+		result, err := GenerateRand32(max)
+		if err != nil {
+			t.Fatalf("GenerateRand32(%d) error: %v", max, err)
+		}
 		if result >= uint32(max) {
 			t.Errorf("GenerateRand32(%d) = %d, want < %d", max, result, max)
 		}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -19,7 +19,10 @@ import (
 func TestRandStringBytes(t *testing.T) {
 	t.Parallel()
 	n := 16
-	result := RandStringBytes(n)
+	result, err := RandStringBytes(n)
+	if err != nil {
+		t.Fatalf("RandStringBytes(%d) error: %v", n, err)
+	}
 	if len(result) != n {
 		t.Errorf("Result was improper length. Got: %d Want: %d", len(result), n)
 	}
@@ -32,7 +35,10 @@ func TestRandStringBytes(t *testing.T) {
 func TestGenerateRand16(t *testing.T) {
 	t.Parallel()
 	n := 16
-	result := GenerateRand16(n)
+	result, err := GenerateRand16(n)
+	if err != nil {
+		t.Fatalf("GenerateRand16(%d) error: %v", n, err)
+	}
 	if result > uint16(n) {
 		t.Errorf("Result was larger than expected max! Got: %d Want less than: %d", result, n)
 	}
@@ -41,7 +47,10 @@ func TestGenerateRand16(t *testing.T) {
 func TestGenerateRand32(t *testing.T) {
 	t.Parallel()
 	n := 16
-	result := GenerateRand32(n)
+	result, err := GenerateRand32(n)
+	if err != nil {
+		t.Fatalf("GenerateRand32(%d) error: %v", n, err)
+	}
 	if result > uint32(n) {
 		t.Errorf("Result was larger than expected max! Got: %d Want less than: %d", result, n)
 	}
@@ -81,7 +90,10 @@ func TestRandomNum(t *testing.T) {
 	for range count {
 		min := 10
 		max := 250
-		result := RandomNum(min, max)
+		result, err := RandomNum(min, max)
+		if err != nil {
+			t.Fatalf("RandomNum(%d, %d) error: %v", min, max, err)
+		}
 		if result > max {
 			t.Errorf("Result is greater than max! Got: %d Want: %d", result, max)
 		}


### PR DESCRIPTION
## Summary

Convert all random number generation functions from panic-based error handling to proper error returns.

## Changes

### Core — `utils/rand.go`
- `CryptoRandomNumber` now returns `(`int64`, error)` instead of panicking on `rand.Int` failure
- `GenerateRand16`, `GenerateRand32`, `RandomNum`, `RandStringBytes` now return errors

### Flow generation (all `Generate` methods return errors)
- **netflow**: `GenericFlow`, `MinimalFlow`, `ExtendedFlow`, `DataFlowSet`
- **ipfix**: `GenericFlow`, `MinimalIPFIXFlow`, `DataFlowSet`

### Call sites (all now handle errors)
- `barrage/barrage.go` — srcPort, flowCount, sourceID
- `proxy/proxy.go` — srcPort
- `replay/replay.go` — srcPort
- `single/single.go` — srcPort, sourceID
- `cmd/ipfix_single.go` — srcPort, sourceID
- `utils/ip.go` — `RandomIP`

### Tests
- All test files updated to handle new error-return signatures

## Motivation

Panicking on `rand.Int` failure is not ideal — `crypto/rand` failures are rare but recoverable. Propagating errors gives callers control over how to handle them (log, retry, abort gracefully) instead of crashing the process.

## Verification

- All tests pass (`go test -count=1 ./...`)
- `go vet ./...` is clean